### PR TITLE
feat(cdk): Add Cognito extension to Website stack.

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -14,12 +14,14 @@ import toml = require("@iarna/toml");
 // Load our configuration file to bootstrap CFN configuration.
 const config: any = toml.parse(fs.readFileSync("../config.toml", "utf8"));
 
+// Map constants
 const STATE_FILE = config.base.state_file;
-const WEBSITE_REGION = config.website.region;
 const FAYTHE_CMK_REGION = config.faythe_cmk.region;
 const FAYTHE_CMK_ALIAS = config.faythe_cmk.alias;
 const WALTER_CMK_REGION = config.walter_cmk.region;
 const WALTER_CMK_ALIAS = config.walter_cmk.alias;
+
+const WEBSITE_CONFIG = config.website;
 
 const app = new cdk.App();
 
@@ -36,10 +38,15 @@ new CMKStack(app, "BusyEngineersWalterCMKStack", {
 
 // Initialize Document Bucket resources
 new DocumentBucketStack(app, "BusyEngineersDocumentBucketStack", {
-  env: { region: WEBSITE_REGION }
+  env: { region: WEBSITE_CONFIG.region }
 });
 
 // Initialize client website resources
-new WebsiteStack(app, "BusyEngineersWebsiteStack", {
-  env: { region: WEBSITE_REGION }
-});
+const websiteStack = new WebsiteStack(
+  app,
+  "BusyEngineersWebsiteStack",
+  {
+    env: { region: WEBSITE_CONFIG.region }
+  },
+  WEBSITE_CONFIG
+);

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -299,6 +299,16 @@
         "@aws-cdk/core": "1.15.0"
       }
     },
+    "@aws-cdk/aws-cognito": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.15.0.tgz",
+      "integrity": "sha512-GmOl4WHGPpKprKmDIGuU1FJy2wiCs++Fjo1OkMiaVPG9czbd26V30fXjLwqDC94lLHieqUdKEzpsWUSLA7rkGg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.15.0",
+        "@aws-cdk/aws-lambda": "1.15.0",
+        "@aws-cdk/core": "1.15.0"
+      }
+    },
     "@aws-cdk/aws-dynamodb": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.15.0.tgz",
@@ -1064,6 +1074,14 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/iarna__toml": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.0.tgz",
+      "integrity": "sha512-+48FAf1zzwpUflRc1A/+j1BKQiBxUudZczH+jETuQ9BrOzJwA0Du3fJc1jvNymJQ5i5rr8jrHlNzlzF339wT8w==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/istanbul-lib-coverage": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -22,12 +22,14 @@
   "dependencies": {
     "@aws-cdk/aws-cloud9": "^1.15.0",
     "@aws-cdk/aws-cloudfront": "^1.15.0",
+    "@aws-cdk/aws-cognito": "^1.15.0",
     "@aws-cdk/aws-dynamodb": "^1.15.0",
     "@aws-cdk/aws-iam": "^1.15.0",
     "@aws-cdk/aws-kms": "^1.15.0",
     "@aws-cdk/aws-s3": "^1.15.0",
     "@aws-cdk/core": "^1.15.0",
     "@iarna/toml": "^2.2.3",
+    "@types/iarna__toml": "^2.0.0",
     "@types/node": "^12.12.6",
     "source-map-support": "^0.5.16"
   }

--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,14 @@ launch_url = "https://us-east-2.console.aws.amazon.com/cloudformation/home?regio
 
 [website]
 region = "us-east-2"
+user_pool_name = "BusyEngineersUserPool"
+identity_pool_name = "BusyEngineersIdentityPool"
+user_pool_client_name = "BusyEngineersUserPoolClient"
+
+[website.outputs]
+user_pool_name = "BusyEngineersUserPoolOutput"
+identity_pool_name = "BusyEngineersIdentityPoolOutput"
+user_pool_client_name = "BusyEngineersUserPoolClientOutput"
 
 [faythe_cmk]
 region = "us-east-2"


### PR DESCRIPTION
*Description of changes:*

Adds several CFN Outputs to use as hooks for configuring Cognito.

There is bootstrapping work to set up Cognito that is not yet done, this just tells CFN to spin up the resources.

NOTE: This is a partial migration to using more TOML configuration. I would like to do this everywhere, but it's an unrelated change to this changeset. So I am doing this only partially to reduce merge conflicts and keep unrelated changes down.

See: https://github.com/aws-samples/busy-engineers-document-bucket/issues/7

*Issue #, if available:* n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
