### PR TITLE
fix: Plumb through TOML configuration.

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -12,7 +12,9 @@ import fs = require("fs");
 import toml = require("@iarna/toml");
 
 // Load our configuration file to bootstrap CFN configuration.
-const config: any = toml.parse(fs.readFileSync("../config.toml", "utf8"));
+const config: Record<string, any> = toml.parse(
+  fs.readFileSync("../config.toml", "utf8")
+);
 
 // Map constants
 const STATE_FILE = config.base.state_file;

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -7,7 +7,7 @@ import "source-map-support/register";
 import cdk = require("@aws-cdk/core");
 import { CMKStack } from "../lib/kms-cmk-stack";
 import { DocumentBucketStack } from "../lib/document-bucket-stack";
-import { WebsiteStack } from "../lib/website-stack";
+import { WebappStack } from "../lib/webapp-stack";
 import fs = require("fs");
 import toml = require("@iarna/toml");
 
@@ -18,37 +18,48 @@ const config: Record<string, any> = toml.parse(
 
 // Map constants
 const STATE_FILE = config.base.state_file;
-const FAYTHE_CMK_REGION = config.faythe_cmk.region;
-const FAYTHE_CMK_ALIAS = config.faythe_cmk.alias;
-const WALTER_CMK_REGION = config.walter_cmk.region;
-const WALTER_CMK_ALIAS = config.walter_cmk.alias;
-
-const WEBSITE_CONFIG = config.website;
+const WEBAPP_CONFIG = config.webapp;
+const BUCKET_CONFIG = config.document_bucket;
+const FAYTHE_CONFIG = config.faythe;
+const WALTER_CONFIG = config.walter;
 
 const app = new cdk.App();
 
 // Initialize CMK Stacks
-new CMKStack(app, "BusyEngineersFaytheCMKStack", {
-  env: { region: FAYTHE_CMK_REGION },
-  alias: FAYTHE_CMK_ALIAS
-});
+new CMKStack(
+  app,
+  FAYTHE_CONFIG.stack_id,
+  {
+    env: { region: FAYTHE_CONFIG.region }
+  },
+  FAYTHE_CONFIG
+);
 
-new CMKStack(app, "BusyEngineersWalterCMKStack", {
-  env: { region: WALTER_CMK_REGION },
-  alias: WALTER_CMK_ALIAS
-});
+new CMKStack(
+  app,
+  WALTER_CONFIG.stack_id,
+  {
+    env: { region: WALTER_CONFIG.region }
+  },
+  WALTER_CONFIG
+);
 
 // Initialize Document Bucket resources
-new DocumentBucketStack(app, "BusyEngineersDocumentBucketStack", {
-  env: { region: WEBSITE_CONFIG.region }
-});
-
-// Initialize client website resources
-const websiteStack = new WebsiteStack(
+new DocumentBucketStack(
   app,
-  "BusyEngineersWebsiteStack",
+  BUCKET_CONFIG.stack_id,
   {
-    env: { region: WEBSITE_CONFIG.region }
+    env: { region: BUCKET_CONFIG.region }
   },
-  WEBSITE_CONFIG
+  BUCKET_CONFIG
+);
+
+// Initialize client webapp resources
+const webappStack = new WebappStack(
+  app,
+  WEBAPP_CONFIG.stack_id,
+  {
+    env: { region: WEBAPP_CONFIG.region }
+  },
+  WEBAPP_CONFIG
 );

--- a/cdk/lib/document-bucket-stack.ts
+++ b/cdk/lib/document-bucket-stack.ts
@@ -6,19 +6,27 @@ import s3 = require("@aws-cdk/aws-s3");
 import ddb = require("@aws-cdk/aws-dynamodb");
 
 export class DocumentBucketStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(
+    scope: cdk.Construct,
+    id: string,
+    props: cdk.StackProps,
+    config: Record<string, any>
+  ) {
     super(scope, id, props);
 
     // S3 Bucket
-    new s3.Bucket(this, "DocumentBucket", {
+    new s3.Bucket(this, config.bucket.name, {
       accessControl: s3.BucketAccessControl.PRIVATE,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       removalPolicy: cdk.RemovalPolicy.DESTROY
     });
 
     // DynamoDB Table
-    new ddb.Table(this, "DocumentList", {
-      partitionKey: { name: "id", type: ddb.AttributeType.STRING },
+    new ddb.Table(this, config.document_table.name, {
+      partitionKey: {
+        name: config.document_table.partition_key,
+        type: ddb.AttributeType.STRING
+      },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST
     });
   }

--- a/cdk/lib/kms-cmk-stack.ts
+++ b/cdk/lib/kms-cmk-stack.ts
@@ -4,16 +4,17 @@
 import cdk = require("@aws-cdk/core");
 import kms = require("@aws-cdk/aws-kms");
 
-interface CMKStackProps extends cdk.StackProps {
-  alias: string;
-}
-
 export class CMKStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props: CMKStackProps) {
+  constructor(
+    scope: cdk.Construct,
+    id: string,
+    props: cdk.StackProps,
+    config: Record<string, any>
+  ) {
     super(scope, id, props);
 
-    new kms.Key(this, props.alias, {
-      alias: props.alias
+    new kms.Key(this, config.cmk_id, {
+      alias: config.alias
     });
 
     // TODO: Grants

--- a/cdk/lib/website-stack.ts
+++ b/cdk/lib/website-stack.ts
@@ -12,7 +12,7 @@ export class WebsiteStack extends cdk.Stack {
     scope: cdk.Construct,
     id: string,
     props: cdk.StackProps,
-    config: any // FIXME Nail down typing here
+    config: Record<string, any>
   ) {
     super(scope, id, props);
 

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1080,6 +1080,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.0.tgz",
       "integrity": "sha512-+48FAf1zzwpUflRc1A/+j1BKQiBxUudZczH+jETuQ9BrOzJwA0Du3fJc1jvNymJQ5i5rr8jrHlNzlzF339wT8w==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -5227,6 +5228,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-format": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,9 +12,11 @@
   },
   "devDependencies": {
     "@aws-cdk/assert": "^1.15.0",
+    "@types/iarna__toml": "^2.0.0",
     "@types/jest": "^24.0.21",
     "aws-cdk": "^1.15.0",
     "jest": "^24.9.0",
+    "prettier": "^1.19.1",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
     "typescript": "~3.6.2"
@@ -29,7 +31,6 @@
     "@aws-cdk/aws-s3": "^1.15.0",
     "@aws-cdk/core": "^1.15.0",
     "@iarna/toml": "^2.2.3",
-    "@types/iarna__toml": "^2.0.0",
     "@types/node": "^12.12.6",
     "source-map-support": "^0.5.16"
   }

--- a/config.toml
+++ b/config.toml
@@ -5,21 +5,41 @@ state_file = "~/.busy_engineers_state.toml"
 region = "us-east-2"
 launch_url = "https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/quickcreate?templateUrl=https%3A%2F%2Fbusy-engineers-cfn.s3.us-east-2.amazonaws.com%2Fdocument-bucket-cloud9-bootstrap.yaml&stackName=BusyEngineersDocumentBucketEnvironment"
 
-[website]
+[webapp]
+stack_id = "BusyEngineersWebappStack"
 region = "us-east-2"
 user_pool_name = "BusyEngineersUserPool"
 identity_pool_name = "BusyEngineersIdentityPool"
 user_pool_client_name = "BusyEngineersUserPoolClient"
+bucket_name = "BusyEngineersWebappBucket"
+distribution_name = "BusyEngineersWebappDistribution"
+oaid_name = "BusyEngineersOFAID"
+oaid_comment = "Origin Access Identity to allow CloudFront access to serve the Webapp bucket."
 
-[website.outputs]
+[webapp.outputs]
 user_pool_name = "BusyEngineersUserPoolOutput"
 identity_pool_name = "BusyEngineersIdentityPoolOutput"
 user_pool_client_name = "BusyEngineersUserPoolClientOutput"
 
-[faythe_cmk]
+[document_bucket]
+stack_id = "BusyEngineersDocumentBucketStack"
+region = "us-east-2"
+
+[document_bucket.document_table]
+name = "DocumentTable"
+partition_key = "uid"
+
+[document_bucket.bucket]
+name = "DocumentBucket"
+
+[faythe]
+stack_id = "BusyEngineersFaytheCMKStack"
+cmk_id = "BusyEngineersFaytheCMK"
 region = "us-east-2"
 alias = "FaytheCMK"
 
-[walter_cmk]
+[walter]
+stack_id = "BusyEngineersWalterCMKStack"
+cmk_id = "BusyEngineersWalterCMK"
 region = "us-west-2"
 alias = "WalterCMK"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/busy-engineers-document-bucket/issues/7

*Description of changes:* Get rid of use of string constants to configure various CDK resources. Use the TOML configuration file instead.

Also renames "Website" to "Webapp" to be clearer for the student/customer.

Relative to `master`, this change picks up/builds on a commit from https://github.com/aws-samples/busy-engineers-document-bucket/pull/10 and I may wind up force pushing to do cleanup things.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
