### PR TITLE
feat: export cfn output to state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/exercises/busy_engineers_state.toml

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -8,13 +8,7 @@ import cdk = require("@aws-cdk/core");
 import { CMKStack } from "../lib/kms-cmk-stack";
 import { DocumentBucketStack } from "../lib/document-bucket-stack";
 import { WebappStack } from "../lib/webapp-stack";
-import fs = require("fs");
-import toml = require("@iarna/toml");
-
-// Load our configuration file to bootstrap CFN configuration.
-const config: Record<string, any> = toml.parse(
-  fs.readFileSync("../exercises/config.toml", "utf8")
-);
+import { config } from "../lib/config"
 
 // Map constants
 const STATE_FILE = config.base.state_file;

--- a/cdk/bin/cdk_state.ts
+++ b/cdk/bin/cdk_state.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import aws = require("aws-sdk");
+import fs = require("fs");
+import toml = require("@iarna/toml");
+
+const cf = new aws.CloudFormation()
+
+!(async () => {
+  const { Exports = [] } = await cf.listExports().promise()
+
+  const cfnState  = Exports
+    .filter(validExport)
+    .reduce((memo, { Name, Value }) => {
+      memo[Name] = Value
+      return memo
+    }, {} as { [key: string]: string })
+  
+  fs.writeFileSync("../exercises/busy_engineers_state.toml", toml.stringify({ state: cfnState }), {encoding: 'utf8'})
+})()
+
+function validExport(value: aws.CloudFormation.Export) : value is Required<aws.CloudFormation.Export> {
+  return !!value.Name && !!value.Value
+}

--- a/cdk/bin/cdk_state.ts
+++ b/cdk/bin/cdk_state.ts
@@ -6,6 +6,7 @@
 import aws = require("aws-sdk");
 import fs = require("fs");
 import toml = require("@iarna/toml");
+import { config } from "../lib/config"
 
 const cf = new aws.CloudFormation()
 
@@ -19,7 +20,7 @@ const cf = new aws.CloudFormation()
       return memo
     }, {} as { [key: string]: string })
   
-  fs.writeFileSync("../exercises/busy_engineers_state.toml", toml.stringify({ state: cfnState }), {encoding: 'utf8'})
+  fs.writeFileSync(config.base.state_file, toml.stringify({ state: cfnState }), {encoding: 'utf8'})
 })()
 
 function validExport(value: aws.CloudFormation.Export) : value is Required<aws.CloudFormation.Export> {

--- a/cdk/lib/config.ts
+++ b/cdk/lib/config.ts
@@ -1,0 +1,7 @@
+import fs = require("fs");
+import toml = require("@iarna/toml");
+
+// Load our configuration file to bootstrap CFN configuration.
+export const config: Record<string, any> = toml.parse(
+  fs.readFileSync("../exercises/config.toml", "utf8")
+);


### PR DESCRIPTION
Add a simple script to export the CloudFormation outputs to a state file.
The outputs from `config.toml` can be looked up as needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
