### PR TITLE
fix: expand ~ for home directories

### DIFF
--- a/cdk/bin/cdk_state.ts
+++ b/cdk/bin/cdk_state.ts
@@ -7,8 +7,10 @@ import aws = require("aws-sdk");
 import fs = require("fs");
 import toml = require("@iarna/toml");
 import { config } from "../lib/config"
+import untildify = require('untildify')
 
 const cf = new aws.CloudFormation()
+const state_file = untildify(config.base.state_file)
 
 !(async () => {
   const { Exports = [] } = await cf.listExports().promise()
@@ -20,7 +22,7 @@ const cf = new aws.CloudFormation()
       return memo
     }, {} as { [key: string]: string })
   
-  fs.writeFileSync(config.base.state_file, toml.stringify({ state: cfnState }), {encoding: 'utf8'})
+  fs.writeFileSync(state_file, toml.stringify({ state: cfnState }), {encoding: 'utf8', flag: 'w'})
 })()
 
 function validExport(value: aws.CloudFormation.Export) : value is Required<aws.CloudFormation.Export> {

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -6124,6 +6124,11 @@
         }
       }
     },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -32,6 +32,7 @@
     "@aws-cdk/core": "^1.16.3",
     "@iarna/toml": "^2.2.3",
     "@types/node": "^12.12.7",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "untildify": "^4.0.0"
   }
 }


### PR DESCRIPTION
There are many ways to expand `~`.
Node.js does not expand this value.
`untildify` is a good solution to this problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
