### PR TITLE
fix(javascript): Add region config env var

### DIFF
--- a/exercises/node-javascript/Makefile
+++ b/exercises/node-javascript/Makefile
@@ -6,6 +6,8 @@ install_node:
 	@echo "node" > ~/.nvmrc
 	@curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
 	@NVM_DIR=/home/ec2-user/.nvm . "$$NVM_DIR/nvm.sh"; nvm install node
+	echo 'export AWS_SDK_LOAD_CONFIG=1' >> ~/.bashrc
+	. ~/.bashrc
 
 node_modules: 
 	find . -maxdepth 1 -type d \( ! -name . \) -exec bash -c "cd '{}' && npm ci" \;


### PR DESCRIPTION
According to https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html
The AWS SDK JS will only look in the ~/.aws/credentials file if AWS_SDK_LOAD_CONFIG is set.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
