### PR TITLE
fix(docs): Launch external links in new windows.

### DIFF
--- a/instructions/docs/getting-started.md
+++ b/instructions/docs/getting-started.md
@@ -46,7 +46,7 @@ In this exercise, we will walk you through setting up your environment, step by 
 ## Explore Further
 
 * Check out the `~/environment/workshop/cdk` directory to see how the workshop resources are described using CDK
-* <a href="https://en.wikipedia.org/wiki/Alice_and_Bob#Cast_of_characters" target="_blank">Who are Faythe and Walter?</a> And the other characters you may encounter as you explore.
+* <a href="https://en.wikipedia.org/wiki/Alice_and_Bob#Cast_of_characters" target="_blank">Who are Faythe and Walter?</a>
 
 # Next exercise
 

--- a/instructions/docs/getting-started.md
+++ b/instructions/docs/getting-started.md
@@ -10,8 +10,8 @@ In this exercise, we will walk you through setting up your environment, step by 
 * Launch the Cloud9 IDE that you will use to work with the rest of the workshop
 * Launch resource stacks using the AWS Cloud Development Kit (CDK), including
     * The `BusyEngineersDocumentBucket` stack, with your DynamoDB table and S3 bucket
-    * One CMK in one region, called `Faythe`, that you will use in encryption and decryption operations
-    * One CMK in another region, called `Walter`, that you will use in encryption and decryption operations
+    * One CMK in one region, called Faythe, that you will use in encryption and decryption operations
+    * One CMK in another region, called Walter, that you will use in encryption and decryption operations
 * Bootstrap the development environment in Cloud9
 * Start the workshop!
 
@@ -19,10 +19,10 @@ In this exercise, we will walk you through setting up your environment, step by 
 
 1. Sign in to your AWS Account for the workshop
     * Make sure this is **not** a production account! This is a workshop for learning and experimentation. Don't put production at risk!
-1. [Click this link to load the CloudFormation template for your Cloud9 IDE](https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/quickcreate?templateUrl=https%3A%2F%2Fbusy-engineers-cfn.s3.us-east-2.amazonaws.com%2Fdocument-bucket-cloud9-bootstrap.yaml&stackName=BusyEngineersDocumentBucketEnvironment)
+1. <a href=https://us-east-2.console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/quickcreate?templateUrl=https%3A%2F%2Fbusy-engineers-cfn.s3.us-east-2.amazonaws.com%2Fdocument-bucket-cloud9-bootstrap.yaml&stackName=BusyEngineersDocumentBucketEnvironment" target="_blank">Click this link to load the CloudFormation template for your Cloud9 IDE</a>
 1. Click **Create Stack** to launch the stack.
 1. It will take 1-3 minutes to launch your Cloud9 IDE.
-1. [Open the Cloud9 Console](https://us-east-2.console.aws.amazon.com/cloud9/home?region=us-east-2#) to find your Cloud9 IDE. You may need to wait a minute and refresh while CloudFormation spins up the resources
+1. <a href="https://us-east-2.console.aws.amazon.com/cloud9/home?region=us-east-2#" target="_blank">Open the Cloud9 Console</a> to find your Cloud9 IDE. You may need to wait a minute and refresh while CloudFormation spins up the resources
 1. There will be a blue tile with your IDE when it's ready. At the bottom of the tile, click **Open IDE** to launch Cloud9
 1. Type `cd ~/environment/workshop` and hit `Enter`
 1. Execute `make bootstrap` and hit `Enter` to set up your workshop environment
@@ -46,7 +46,7 @@ In this exercise, we will walk you through setting up your environment, step by 
 ## Explore Further
 
 * Check out the `~/environment/workshop/cdk` directory to see how the workshop resources are described using CDK
-* [Who are Faythe and Walter, anyway?](https://en.wikipedia.org/wiki/Alice_and_Bob#Cast_of_characters) And the other characters you may encounter as you explore.
+* <a href="https://en.wikipedia.org/wiki/Alice_and_Bob#Cast_of_characters" target="_blank">Who are Faythe and Walter?</a> And the other characters you may encounter as you explore.
 
 # Next exercise
 

--- a/instructions/docs/multi-cmk.md
+++ b/instructions/docs/multi-cmk.md
@@ -127,8 +127,8 @@ In `~/environment/workshop/exercises`, you'll find a `Makefile` with several tar
 
 You can observe the impact of changing Granted permissions by monitoring CloudTrail.
 
-* Faythe is in `us-east-2`, so [check CloudTrail in us-east-2](https://us-east-2.console.aws.amazon.com/cloudtrail/home?region=us-east-2#)
-* Walter is in `us-west-2`, so [check CloudTrail in us-west-2](https://us-west-2.console.aws.amazon.com/cloudtrail/home?region=us-west-2#/dashboard)
+* Faythe is in `us-east-2`, so <a href="https://us-east-2.console.aws.amazon.com/cloudtrail/home?region=us-east-2#" target="_blank">check CloudTrail in us-east-2</a>
+* Walter is in `us-west-2`, so <a href="https://us-west-2.console.aws.amazon.com/cloudtrail/home?region=us-west-2#/dashboard" target="_blank">check CloudTrail in us-west-2</a>
 
 Try out combinations of Grant permissions for your application and watch how the behavior changes:
 
@@ -154,10 +154,10 @@ tox -e repl
 
 Want to dive into more content related to this exercise? Try out these links.
 
-* [AWS KMS: Key Grants](https://docs.aws.amazon.com/kms/latest/developerguide/grants.html)
-* [AWS KMS: Key Policies](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html)
-* [AWS KMS: Cross-account CMK Usage](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html)
-* [Blog Post: How to decrypt ciphertexts in multiple regions with the AWS Encryption SDK in C](https://aws.amazon.com/blogs/security/how-to-decrypt-ciphertexts-multiple-regions-aws-encryption-sdk-in-c/)
+* <a href="https://docs.aws.amazon.com/kms/latest/developerguide/grants.html" target="_blank">AWS KMS: Key Grants</a>
+* <a href="https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html" target="_blank">AWS KMS: Key Policies</a>
+* <a href="https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html" target="_blank">AWS KMS: Cross-account CMK Usage</a>
+* <a href="https://aws.amazon.com/blogs/security/how-to-decrypt-ciphertexts-multiple-regions-aws-encryption-sdk-in-c/" target="_blank">Blog Post: How to decrypt ciphertexts in multiple regions with the AWS Encryption SDK in C</a>
 
 # Next exercise
 


### PR DESCRIPTION
Fixes https://github.com/aws-samples/busy-engineers-document-bucket/issues/63

*Issue #, if available:* #63

*Description of changes:*
Don't take workshop students away from the exercise content. External links now `target=_blank`. The Markdown/`MkDocs`-way to do that seems to be to directly embed HTML.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
