### PR TITLE
fix: Update version of @aws-crypto/client-node

### DIFF
--- a/exercises/node-javascript/add-esdk-complete/package-lock.json
+++ b/exercises/node-javascript/add-esdk-complete/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }
@@ -177,9 +177,9 @@
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/node": {
-      "version": "12.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "version": "12.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+      "integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
     },
     "asn1.js": {
       "version": "5.2.0",

--- a/exercises/node-javascript/add-esdk-complete/package.json
+++ b/exercises/node-javascript/add-esdk-complete/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "aws-sdk": "^2.568.0",
     "commander": "^4.0.1",

--- a/exercises/node-javascript/add-esdk-start/package-lock.json
+++ b/exercises/node-javascript/add-esdk-start/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }
@@ -177,9 +177,9 @@
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/node": {
-      "version": "12.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "version": "12.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+      "integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
     },
     "asn1.js": {
       "version": "5.2.0",

--- a/exercises/node-javascript/add-esdk-start/package.json
+++ b/exercises/node-javascript/add-esdk-start/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "aws-sdk": "^2.568.0",
     "commander": "^4.0.1",

--- a/exercises/node-javascript/encryption-context-complete/package-lock.json
+++ b/exercises/node-javascript/encryption-context-complete/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }
@@ -177,9 +177,9 @@
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/node": {
-      "version": "12.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "version": "12.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+      "integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
     },
     "asn1.js": {
       "version": "5.2.0",

--- a/exercises/node-javascript/encryption-context-complete/package.json
+++ b/exercises/node-javascript/encryption-context-complete/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "aws-sdk": "^2.568.0",
     "commander": "^4.0.1",

--- a/exercises/node-javascript/encryption-context-start/package-lock.json
+++ b/exercises/node-javascript/encryption-context-start/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }
@@ -177,9 +177,9 @@
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/node": {
-      "version": "12.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "version": "12.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+      "integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
     },
     "asn1.js": {
       "version": "5.2.0",

--- a/exercises/node-javascript/encryption-context-start/package.json
+++ b/exercises/node-javascript/encryption-context-start/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "aws-sdk": "^2.568.0",
     "commander": "^4.0.1",

--- a/exercises/node-javascript/multi-cmk-complete/package-lock.json
+++ b/exercises/node-javascript/multi-cmk-complete/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }
@@ -177,9 +177,9 @@
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/node": {
-      "version": "12.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "version": "12.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+      "integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
     },
     "asn1.js": {
       "version": "5.2.0",

--- a/exercises/node-javascript/multi-cmk-complete/package.json
+++ b/exercises/node-javascript/multi-cmk-complete/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "aws-sdk": "^2.568.0",
     "commander": "^4.0.1",

--- a/exercises/node-javascript/multi-cmk-start/package-lock.json
+++ b/exercises/node-javascript/multi-cmk-start/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }
@@ -177,9 +177,9 @@
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/node": {
-      "version": "12.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "version": "12.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+      "integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
     },
     "asn1.js": {
       "version": "5.2.0",

--- a/exercises/node-javascript/multi-cmk-start/package.json
+++ b/exercises/node-javascript/multi-cmk-start/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "aws-sdk": "^2.568.0",
     "commander": "^4.0.1",

--- a/exercises/node-typescript/add-esdk-complete/package-lock.json
+++ b/exercises/node-typescript/add-esdk-complete/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }

--- a/exercises/node-typescript/add-esdk-complete/package.json
+++ b/exercises/node-typescript/add-esdk-complete/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "@types/commander": "^2.12.2",
     "aws-sdk": "^2.568.0",

--- a/exercises/node-typescript/add-esdk-start/package-lock.json
+++ b/exercises/node-typescript/add-esdk-start/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }

--- a/exercises/node-typescript/add-esdk-start/package.json
+++ b/exercises/node-typescript/add-esdk-start/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "@types/commander": "^2.12.2",
     "aws-sdk": "^2.568.0",

--- a/exercises/node-typescript/encryption-context-complete/package-lock.json
+++ b/exercises/node-typescript/encryption-context-complete/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }

--- a/exercises/node-typescript/encryption-context-complete/package.json
+++ b/exercises/node-typescript/encryption-context-complete/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "@types/commander": "^2.12.2",
     "aws-sdk": "^2.568.0",

--- a/exercises/node-typescript/encryption-context-start/package-lock.json
+++ b/exercises/node-typescript/encryption-context-start/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }

--- a/exercises/node-typescript/encryption-context-start/package.json
+++ b/exercises/node-typescript/encryption-context-start/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "@types/commander": "^2.12.2",
     "aws-sdk": "^2.568.0",

--- a/exercises/node-typescript/multi-cmk-complete/package-lock.json
+++ b/exercises/node-typescript/multi-cmk-complete/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }

--- a/exercises/node-typescript/multi-cmk-complete/package.json
+++ b/exercises/node-typescript/multi-cmk-complete/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "@types/commander": "^2.12.2",
     "aws-sdk": "^2.568.0",

--- a/exercises/node-typescript/multi-cmk-start/package-lock.json
+++ b/exercises/node-typescript/multi-cmk-start/package-lock.json
@@ -17,36 +17,36 @@
       }
     },
     "@aws-crypto/caching-materials-manager-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.1.tgz",
-      "integrity": "sha512-Vx3ZnTLS/OxNlZuEgniveUpsx0GldMZ92DoRZe0+vl9V1FRXDpawXE5bv/7smQw7A5KBLrUNgLwK9F0A9FrLGQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-1.0.2.tgz",
+      "integrity": "sha512-w1czDKNyCTtvF6lwB0EuNtakggT65rBpHgWPFkrZK3jZTuyQvWddQVEdpqFL9U6/2DC3raBOIRYep5xm5uCpeQ==",
       "requires": {
         "@aws-crypto/cache-material": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/client-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.1.tgz",
-      "integrity": "sha512-y4YFjrHC7MrjT8IMtCMxXjHcCllN2Sb9LgTbggzv/50TrmVnU/xVZVw2zsTQJTOtzWYuJadpbi+fbz2WYJPjuQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-1.0.2.tgz",
+      "integrity": "sha512-R5kdgYJuxFVVdkpzVbpamO5iDurFDrUiBoStxOoj4+NXk2b68Il4axmG7YfRQeF5XRlX8X1uB0EkaqkHm+amwg==",
       "requires": {
-        "@aws-crypto/caching-materials-manager-node": "^1.0.1",
-        "@aws-crypto/decrypt-node": "^1.0.1",
-        "@aws-crypto/encrypt-node": "^1.0.1",
-        "@aws-crypto/kms-keyring-node": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
-        "@aws-crypto/raw-aes-keyring-node": "^1.0.1",
-        "@aws-crypto/raw-rsa-keyring-node": "^1.0.1",
+        "@aws-crypto/caching-materials-manager-node": "^1.0.2",
+        "@aws-crypto/decrypt-node": "^1.0.2",
+        "@aws-crypto/encrypt-node": "^1.0.2",
+        "@aws-crypto/kms-keyring-node": "^1.0.2",
+        "@aws-crypto/material-management-node": "^1.0.2",
+        "@aws-crypto/raw-aes-keyring-node": "^1.0.2",
+        "@aws-crypto/raw-rsa-keyring-node": "^1.0.2",
         "tslib": "^1.9.3"
       }
     },
     "@aws-crypto/decrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.1.tgz",
-      "integrity": "sha512-j5lRW+oEHLrg0DWYTOLwF5+GSl/+NwDqBNHEtm85mSf1C21D2WbPZN087m50GKJkeFF2na4fK96Mp9b3rJxPjg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-1.0.2.tgz",
+      "integrity": "sha512-BCi8Ol90HbOgX0cu4x0a7C//5zM2GWsMGkz+HrvJ5bGzkjS2aEmhCaqZdU3+FowRVjG329oNEvfGSMc5mgMHNw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -55,11 +55,11 @@
       }
     },
     "@aws-crypto/encrypt-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.1.tgz",
-      "integrity": "sha512-Fw4gby2TUX7IwX81SieI0uoEsYTmLUJjijm4mVvAKoDZRuHj1Bcn+FyLUMprrmssbFialL7hzjOnwUMFR2Hg2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-1.0.2.tgz",
+      "integrity": "sha512-7ZpwiZ2Ka+2WIK5Ef2TeHdxBgl9Pg/44hX42OVg8Cj4h3ntbd6iH6tLb9JYEfZHzCr+ABW2WOyzvSal6Ce4VXw==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/serialize": "^1.0.1",
         "@types/duplexify": "^3.6.0",
         "duplexify": "^4.0.0",
@@ -85,12 +85,12 @@
       }
     },
     "@aws-crypto/kms-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-FozBjzBE1F7Jf7dJgZDX4s+kHhz2eRzEi+QHeTTPg2BldyQ9vcEqrRdCmq2SDPQcAY6Fjm8MH5anl4jLB8gwOQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-dKeoH4Eahy1mepmxxAwxcBZgjpfayDnGcMhixO6piDzN+45YmV6VIjjcgpIwmlzgx6YnknTIdIqDlC49/VbHWw==",
       "requires": {
         "@aws-crypto/kms-keyring": "^1.0.1",
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "aws-sdk": "^2.443.0",
         "tslib": "^1.9.3"
       }
@@ -106,9 +106,9 @@
       }
     },
     "@aws-crypto/material-management-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.1.tgz",
-      "integrity": "sha512-Y6oqT563zlGDR2lQdhA7oy3TX7uGM7NN9IvxaIbN3AjFCtlRpiug66F5xjLq1GecdWBeKXwJAE0FqsOb10tspA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-1.0.2.tgz",
+      "integrity": "sha512-LtdTewS91SIuf50m2t7oNE8OcVaAzn094haopG1Ow0bD26TJdAHk60nRmeSvj3WIO9aaaySh2B3pxQBPxp6aqA==",
       "requires": {
         "@aws-crypto/hkdf-node": "^1.0.0",
         "@aws-crypto/material-management": "^1.0.1",
@@ -117,11 +117,11 @@
       }
     },
     "@aws-crypto/raw-aes-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-xBWta76mQ9ffLnBHTwqtZq2jpxiw1UslWefTcS5oiC1J3VvxgapKQsbhCV3mQZIDczxpilfVxD6wRCpdEfuDAg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-UpzrrcwWQT5+yrC7BsCMhgZUFTuKoTMtj9nKC6x18wNLov9ax8kRvOvIhyMbJL6dYXsMXCo/GDDyzREyTsSyIQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "@aws-crypto/serialize": "^1.0.1",
         "tslib": "^1.9.3"
@@ -138,11 +138,11 @@
       }
     },
     "@aws-crypto/raw-rsa-keyring-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.1.tgz",
-      "integrity": "sha512-A7DFrk1hv/Z4eUFfTMxS9X2zvditsMWYA0dV3AhbQDyNZir02JlrCErEbklPbbHItdH+CnSlVqemWR0/F0O2KQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-1.0.2.tgz",
+      "integrity": "sha512-FJE7Vb/iSm/lUcWWfoe1osYXYfPiQxeRobhPmZBP8SLq2FwVJKEk+D0vBnz+WQUfqTAnXCpXHawAz+QXs4x0CQ==",
       "requires": {
-        "@aws-crypto/material-management-node": "^1.0.1",
+        "@aws-crypto/material-management-node": "^1.0.2",
         "@aws-crypto/raw-keyring": "^1.0.1",
         "tslib": "^1.9.3"
       }

--- a/exercises/node-typescript/multi-cmk-start/package.json
+++ b/exercises/node-typescript/multi-cmk-start/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-crypto/client-node": "^1.0.1",
+    "@aws-crypto/client-node": "^1.0.2",
     "@iarna/toml": "^2.2.3",
     "@types/commander": "^2.12.2",
     "aws-sdk": "^2.568.0",


### PR DESCRIPTION
Bump to latest version 1.0.2 for Typescript and Javascript

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
