### PR TITLE
fix(cdk): make state typescript error

### DIFF
--- a/cdk/Makefile
+++ b/cdk/Makefile
@@ -4,7 +4,7 @@
 bootstrap: | install deploy state create_grants
 
 install:
-	npm install
+	npm ci
 
 deploy:
 	npx cdk deploy BusyEngineersDocumentBucketStack --require-approval never

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1018,8 +1018,7 @@
     "arg": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
-      "dev": true
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw=="
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -2069,8 +2068,7 @@
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-      "dev": true
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -4463,8 +4461,7 @@
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
-      "dev": true
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -6127,7 +6124,6 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.2.tgz",
       "integrity": "sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==",
-      "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
@@ -6166,10 +6162,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
-      "dev": true
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
     },
     "uglify-js": {
       "version": "3.6.9",
@@ -6575,8 +6570,7 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "zip-stream": {
       "version": "2.1.2",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -18,9 +18,7 @@
     "aws-cdk": "^1.17.0",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
-    "ts-jest": "^24.0.2",
-    "ts-node": "^8.5.2",
-    "typescript": "~3.6.2"
+    "ts-jest": "^24.0.2"
   },
   "dependencies": {
     "@aws-cdk/aws-cloud9": "^1.17.0",
@@ -35,6 +33,8 @@
     "@iarna/toml": "^2.2.3",
     "@types/node": "^12.12.11",
     "source-map-support": "^0.5.16",
+    "typescript": "^3.7.2",
+    "ts-node": "^8.5.2",
     "untildify": "^4.0.0"
   }
 }


### PR DESCRIPTION
resolves #99

* Move typescript and ts-node to `dependencies`
* Update typescript version
* Update package-lock
* change make file to `npm ci` for reproducable builds in the workshop


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
