### PR TITLE
feat(cdk): Encrypt S3 buckets by default

### DIFF
--- a/cdk/lib/document-bucket-stack.ts
+++ b/cdk/lib/document-bucket-stack.ts
@@ -17,7 +17,8 @@ export class DocumentBucketStack extends cdk.Stack {
     const s3Bucket = new s3.Bucket(this, config.bucket.name, {
       accessControl: s3.BucketAccessControl.PRIVATE,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: cdk.RemovalPolicy.DESTROY
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      encryption: s3.BucketEncryption.KMS_MANAGED
     });
 
     const ddbTable = new ddb.Table(this, config.document_table.name, {

--- a/cdk/lib/webapp-stack.ts
+++ b/cdk/lib/webapp-stack.ts
@@ -60,7 +60,8 @@ export class WebappStack extends cdk.Stack {
     // not a S3 static website bucket.
     const webappBucket = new s3.Bucket(this, config.bucket_name, {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      removalPolicy: cdk.RemovalPolicy.DESTROY
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      encryption: s3.BucketEncryption.KMS_MANAGED
     });
 
     // Build a policy to allow the OAID access to the bucket.


### PR DESCRIPTION
resolves #2

Make sure the buckets are encrypted by default.
This workshop is **NOT** for production data.
The S3 examples should be as conservative
and security-conscious as possible.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
