### PR TITLE
fix(cdk): composed targets MUST be serial

### DIFF
--- a/cdk/Makefile
+++ b/cdk/Makefile
@@ -1,21 +1,29 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+.NOTPARALLEL:
+
 bootstrap: | install deploy state create_grants
 
 install:
 	npm ci
 
 deploy:
+	@echo "*** START CDK STACK DEPLOYMENT ***"
 	npx cdk deploy BusyEngineersDocumentBucketStack --require-approval never
 	npx cdk deploy BusyEngineersFaytheCMKStack --require-approval never
 	npx cdk deploy BusyEngineersWalterCMKStack --require-approval never
+	@echo "*** CDK STACK DEPLOYMENT COMPLETE ***"
 
 state:
+	@echo "*** START CDK STATE STORAGE ***"
 	npx ts-node bin/cdk_state.ts
+	@echo "*** CDK STATE STORAGE COMPLETE***"
 
 create_grants:
+	@echo "*** START CDK CREATE GRANTS ***"
 	npx ts-node bin/create_grants.ts
+	@echo "*** CDK CREATE GRANTS COMPLETE***"
 	
 revoke_grants: revoke_walter_grant revoke_faythe_grant
 


### PR DESCRIPTION
This is especially important for the bootstrap target.
The deploy *must* complete before the state or grants can be processed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
