### PR TITLE
feat(java): Javadoc all the things.

### DIFF
--- a/exercises/java/add-esdk-complete/Makefile
+++ b/exercises/java/add-esdk-complete/Makefile
@@ -5,3 +5,7 @@ coverage:
 	cd ./target/site/jacoco/; python3 -m http.server &
 	elinks http://localhost:8000
 	killall python3
+
+javadoc:
+	mvn javadoc:javadoc
+	cd ./target/site/apidocs; python3 -m http.server

--- a/exercises/java/add-esdk-complete/checkstyle.xml
+++ b/exercises/java/add-esdk-complete/checkstyle.xml
@@ -23,7 +23,7 @@
     </module>
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->

--- a/exercises/java/add-esdk-complete/pom.xml
+++ b/exercises/java/add-esdk-complete/pom.xml
@@ -174,7 +174,7 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 // ADD-ESDK-COMPLETE: Add the ESDK Dependency
@@ -29,6 +26,7 @@ import sfw.example.esdkworkshop.datamodel.ContextItem;
 import sfw.example.esdkworkshop.datamodel.DocumentBundle;
 import sfw.example.esdkworkshop.datamodel.PointerItem;
 
+/** Defines the public interface to the Document Bucket operations. */
 public class Api {
   private final AmazonDynamoDB ddbClient;
   private final AmazonS3 s3Client;
@@ -38,6 +36,16 @@ public class Api {
   private final String tableName;
   private final String bucketName;
 
+  /**
+   * Construct a Document Bucket {@code Api} using a default {@link AwsCrypto} instance.
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   public Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -49,6 +57,19 @@ public class Api {
     this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
   }
 
+  /**
+   * Construct a Document Bucket {@code Api} using the provided {@link AwsCrypto} instance.
+   * (Included to facilitate unit testing.)
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param awsEncryptionSdk the {@link AwsCrypto} instance to use for Encryption and Decryption
+   *     operations.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   protected Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -66,22 +87,47 @@ public class Api {
     this.mkp = mkp;
   }
 
+  /**
+   * Writes a {@link BaseItem} item to the DynamoDB table.
+   *
+   * @param modeledItem the item to write.
+   * @param <T> the subtype of item to write.
+   * @return the actual item value written ({@link Map} of {@link String}:{@link AttributeValue}).
+   */
   protected <T extends BaseItem> Map<String, AttributeValue> writeItem(T modeledItem) {
     Map<String, AttributeValue> ddbItem = modeledItem.toItem();
     ddbClient.putItem(tableName, ddbItem);
     return ddbItem;
   }
 
+  /**
+   * Retrieves a {@link PointerItem} for the supplied key.
+   *
+   * @param key the key for which to fetch the {@link PointerItem}.
+   * @return the {@link PointerItem} found.
+   */
   protected PointerItem getPointerItem(String key) {
     GetItemResult result = ddbClient.getItem(tableName, PointerItem.atKey(key));
     PointerItem pointer = PointerItem.fromItem(result.getItem());
     return pointer;
   }
 
+  /**
+   * Retrieves the {@link PointerItem} for an associated {@link ContextItem}-pointer pair.
+   *
+   * @param contextItem the {@link ContextItem} with the desired document pointer key.
+   * @return the {@link PointerItem} for that context and pointer pair.
+   */
   protected PointerItem getPointerItem(ContextItem contextItem) {
     return getPointerItem(contextItem.sortKey().getS());
   }
 
+  /**
+   * Query DynamoDB for the records associated with the supplied context key.
+   *
+   * @param contextKey the key for which to retrieve the list of matching records.
+   * @return the {@link Set} of {@link PointerItem}s that have that context key.
+   */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
     QueryResult result = ddbClient.query(ContextItem.queryFor(contextKey).withTableName(tableName));
     Set<ContextItem> contextItems =
@@ -91,6 +137,12 @@ public class Api {
     return pointerItems;
   }
 
+  /**
+   * Helper to perform the write operations required to store the provided {@link DocumentBundle} in
+   * the Document Bucket system.
+   *
+   * @param bundle the document to store.
+   */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setUserMetadata(bundle.getPointer().getContext());
@@ -101,8 +153,12 @@ public class Api {
         metadata);
   }
 
-  // TODO Return some kind of bundle so that data has been pulled from the stream
-  // but metadata is returned as well?
+  /**
+   * Retrieve the bytes associated with the key in S3.
+   *
+   * @param key the S3 key to retrieve.
+   * @return the bytes for that key.
+   */
   protected byte[] getObjectData(String key) {
     S3Object object = s3Client.getObject(bucketName, key);
     byte[] result;
@@ -114,6 +170,13 @@ public class Api {
     return result;
   }
 
+  /**
+   * Lists all of the Document Bucket {@link PointerItem}s in the DynamoDB table.
+   *
+   * <p>These correspond to documents in the Document Bucket.
+   *
+   * @return the {@link Set} of {@link PointerItem}s in the Document Bucket.
+   */
   public Set<PointerItem> list() {
     ScanResult result = ddbClient.scan(tableName, PointerItem.filterFor());
     Set<PointerItem> mappedItems =
@@ -121,12 +184,26 @@ public class Api {
     return mappedItems;
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket.
+   *
+   * @param data the data to store.
+   * @return the {@link PointerItem} under which this data is stored.
+   */
   public PointerItem store(byte[] data) {
     return store(data, Collections.emptyMap());
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket, along with the supplied
+   * Context.
+   *
+   * @param data the data to store.
+   * @param context the context for this data.
+   * @return the {@link PointerItem} under which this data and context are stored.
+   */
   public PointerItem store(byte[] data, Map<String, String> context) {
-   // ADD-ESDK-COMPLETE: Add Encryption to store
+    // ADD-ESDK-COMPLETE: Add Encryption to store
     CryptoResult<byte[], KmsMasterKey> encryptedMessage = awsEncryptionSdk.encryptData(mkp, data);
     DocumentBundle bundle =
         DocumentBundle.fromDataAndContext(encryptedMessage.getResult(), context);
@@ -135,18 +212,46 @@ public class Api {
     return bundle.getPointer();
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key) {
     return retrieve(key, Collections.emptySet(), Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Set<String> expectedContextKeys) {
     return retrieve(key, expectedContextKeys, Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Map<String, String> expectedContext) {
     return retrieve(key, Collections.emptySet(), expectedContext);
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(
       String key, Set<String> expectedContextKeys, Map<String, String> expectedContext) {
     byte[] data = getObjectData(key);
@@ -157,6 +262,12 @@ public class Api {
     return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
   }
 
+  /**
+   * Search the Document Bucket for any documents that have context with the supplied key.
+   *
+   * @param contextKey the key for which to search for matching documents.
+   * @return the {@link Set} of {@link PointerItem}s for matching documents.
+   */
   public Set<PointerItem> searchByContextKey(String contextKey) {
     return queryForContextKey(contextKey);
   }

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -103,7 +103,7 @@ public class Api {
   /**
    * Retrieves a {@link PointerItem} for the supplied key.
    *
-   * @param key the key for which to fetch the {@link PointerItem}.
+   * @param key the key to fetch the {@link PointerItem}.
    * @return the {@link PointerItem} found.
    */
   protected PointerItem getPointerItem(String key) {
@@ -125,7 +125,7 @@ public class Api {
   /**
    * Query DynamoDB for the records associated with the supplied context key.
    *
-   * @param contextKey the key for which to retrieve the list of matching records.
+   * @param contextKey the key to retrieve the list of matching records.
    * @return the {@link Set} of {@link PointerItem}s that have that context key.
    */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
@@ -265,7 +265,7 @@ public class Api {
   /**
    * Search the Document Bucket for any documents that have context with the supplied key.
    *
-   * @param contextKey the key for which to search for matching documents.
+   * @param contextKey the key to search for matching documents.
    * @return the {@link Set} of {@link PointerItem}s for matching documents.
    */
   public Set<PointerItem> searchByContextKey(String contextKey) {

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/App.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 // ADD-ESDK-COMPLETE: Add the ESDK Dependency
@@ -10,11 +7,22 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
+/**
+ * Entry point for writing logic to work with the Document Bucket, with a helper to obtain an API
+ * instance to use.
+ */
 public class App {
 
   // The names of resources from the configuration file must exactly match those
   // keys for the automatic mapping.
   // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+  /**
+   * Obtain a Document Bucket API initialized with the resources as configured by the bootstrap
+   * configuration system.
+   *
+   * @return a new {@link Api} configured automatically by the bootstrapping system.
+   */
   public static Api initializeDocumentBucket() {
     // Load the TOML State file with the information about launched CloudFormation resources
     State state = new State(Config.contents.base.state_file);
@@ -39,6 +47,11 @@ public class App {
   }
   // CHECKSTYLE:ON AbbreviationAsWordInName
 
+  /**
+   * Entry point for writing logic to interact with the Document Bucket system.
+   *
+   * @param args the command-line arguments to the Document Bucket.
+   */
   public static void main(String[] args) {
     // Interact with the Document Bucket here or in jshell (mvn jshell:run)
   }

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Config.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Config.java
@@ -1,11 +1,9 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
+/** Helper to pull required Document Bucket configuration keys out of the configuration system. */
 public class Config {
   private static final File DEFAULT_CONFIG = new File("../../config.toml");
   public static final ConfigContents contents =
@@ -17,8 +15,12 @@ public class Config {
   // For automatic mpaping, these classes all have names dictated by the TOML file.
   // CHECKSTYLE:OFF MemberName
   // CHECKSTYLE:OFF ParameterName
+
+  /** The top-level contents of the configuration file. */
   public static class ConfigContents {
+    /** The [base] section of the configuration file. */
     public final Base base;
+    /** The [document_bucket] section of the configuration file. */
     public final DocumentBucket document_bucket;
 
     ConfigContents(Base base, DocumentBucket document_bucket) {
@@ -27,7 +29,9 @@ public class Config {
     }
   }
 
+  /** The [base] section of the configuration file. */
   public static class Base {
+    /** The location of the state file for CloudFormation-managed AWS resource identifiers. */
     public final String state_file;
 
     Base(String state_file) {
@@ -35,8 +39,11 @@ public class Config {
     }
   }
 
+  /** The [document_bucket] section of the configuration file. */
   public static class DocumentBucket {
+    /** The [document_bucket.document_table] section of the configuration file. */
     public final DocumentTable document_table;
+    /** The [document_bucket.bucket] section of the configuration file. */
     public final Bucket bucket;
 
     DocumentBucket(DocumentTable document_table, Bucket bucket) {
@@ -45,15 +52,24 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.document_table] section of the configuration file. */
   public static class DocumentTable {
+    /** Table name. */
     public final String name;
 
+    /** Table partition key name on items. */
     public final String partition_key;
 
+    /** Item sort key name on items. */
     public final String sort_key;
 
+    /** The identifier for pointer records indicating that this record is for an S3 object. */
     public final String object_target;
 
+    /**
+     * The prefix for context records to indicate that this record is for a list of documents
+     * matching a context key.
+     */
     public final String ctx_prefix;
 
     DocumentTable(
@@ -70,9 +86,13 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.bucket] section of the configuration file. */
   public static class Bucket {
+    /** Bucket name. */
     public final String name;
+    /** The identifier of the CloudFormation output. */
     public final String output;
+    /** The identifier of the CloudFormation export. */
     public final String export;
 
     Bucket(String name, String output, String export) {

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
@@ -1,5 +1,6 @@
 package sfw.example.esdkworkshop;
 
+/** Exception to wrap errors encountered during Document Bucket operations. */
 public class DocumentBucketException extends RuntimeException {
   public DocumentBucketException(String message, Throwable cause) {
     super(message, cause);

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/State.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/State.java
@@ -3,21 +3,36 @@ package sfw.example.esdkworkshop;
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
-// For automatic mpaping, these classes all have names dictated by the TOML file.
+// For automatic mapping, these classes all have names dictated by the TOML file.
 // CHECKSTYLE:OFF MemberName
 // CHECKSTYLE:OFF ParameterName
 // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+/**
+ * Helper to pull configuration of CloudFormation-managed AWS resources out of the generated state
+ * file.
+ */
 public class State {
   public final Contents contents;
 
+  /**
+   * Parse the state file at the provided path.
+   *
+   * @param path the path to the state file.
+   */
   public State(String path) {
     contents = new Toml().read(new File(path)).to(Contents.class);
   }
 
+  /** The top-level content structure of the state file. */
   public static class Contents {
+    /** The name of the Document Bucket S3 bucket. */
     public final String DocumentBucket;
+    /** The name of the Document Bucket DynamoDB table. */
     public final String DocumentTable;
+    /** The ARN of Faythe's CMK. */
     public final String FaytheCMK;
+    /** The ARN of Walter's CMK. */
     public final String WalterCMK;
 
     Contents(String DocumentBucket, String DocumentTable, String FaytheCMK, String WalterCMK) {

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -9,6 +6,11 @@ import java.util.Map;
 import java.util.Objects;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
+ * for items corresponding to key records for indexing items with a context key. See {@link
+ * PointerItem} for items corresponding to pointer records for documents.
+ */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;
   protected final AttributeValue sortKey;
@@ -22,6 +24,12 @@ public abstract class BaseItem {
     this.sortKey = new AttributeValue(sortKey);
   }
 
+  /**
+   * Transform this modeled item into a DynamoDB item ready to write to the table.
+   *
+   * @return the item in {@link Map} of ({@link String}, {@link AttributeValue}) pairs, ready to
+   *     write.
+   */
   public Map<String, AttributeValue> toItem() {
     Map<String, AttributeValue> item = new HashMap<>();
     item.put(PARTITION_KEY_NAME, partitionKey);
@@ -29,18 +37,38 @@ public abstract class BaseItem {
     return item;
   }
 
+  /**
+   * Return the name of the item attribute used as partition key.
+   *
+   * @return the partition key item attribute name.
+   */
   public static String partitionKeyName() {
     return PARTITION_KEY_NAME;
   }
 
+  /**
+   * Return the name of the item attribute used as sort key.
+   *
+   * @return the sort key item attribute name.
+   */
   public static String sortKeyName() {
     return SORT_KEY_NAME;
   }
 
+  /**
+   * Return the value of this item's partition key attribute.
+   *
+   * @return the value of the partition key attribute.
+   */
   public AttributeValue partitionKey() {
     return this.partitionKey;
   }
 
+  /**
+   * Return the value of this item's sort key attribute.
+   *
+   * @return the value of the sort key attribute.
+   */
   public AttributeValue sortKey() {
     return this.sortKey;
   }

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -10,6 +7,10 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import java.util.Map;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket context item. Context Items are DynamoDB items
+ * that maintain lists of which Document Bucket items have which metadata keys.
+ */
 public class ContextItem extends BaseItem {
   protected static final String PREFIX = Config.contents.document_bucket.document_table.ctx_prefix;
 
@@ -17,6 +18,12 @@ public class ContextItem extends BaseItem {
     super(contextKey, objectTarget.toString());
   }
 
+  /**
+   * Ensure that the provided key is in canonical form as a {@code ContextItem} partition key.
+   *
+   * @param key the key to canonicalize (if needed).
+   * @return a canonicalized {@code key}, if it was not already in canonical form.
+   */
   protected static String canonicalize(String key) {
     if (key.startsWith(PREFIX)) {
       return key;
@@ -24,6 +31,13 @@ public class ContextItem extends BaseItem {
     return PREFIX + key;
   }
 
+  /**
+   * Helper to build a DynamoDB {@link QueryRequest} for the provided context key. This query will
+   * return pointer records that have this context key in their context.
+   *
+   * @param contextKey the context key to search for.
+   * @return the {@link QueryRequest} to find matching records in DynamoDB.
+   */
   public static QueryRequest queryFor(String contextKey) {
     Condition keyIsContextKey =
         new Condition()
@@ -34,19 +48,46 @@ public class ContextItem extends BaseItem {
     return query;
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, String objectTarget) {
     UuidKey target = new UuidKey(objectTarget);
     return new ContextItem(canonicalize(key), target);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, UuidKey objectTarget) {
     return new ContextItem(canonicalize(key), objectTarget);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, AttributeValue objectTarget) {
     return fromContext(key, objectTarget.getS());
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link ContextItem}.
+   *
+   * @param item the modeled {@link ContextItem}.
+   * @return a {@link ContextItem} for the provided item contents.
+   */
   public static ContextItem fromItem(Map<String, AttributeValue> item) {
     String contextKey = item.get(partitionKeyName()).getS();
     String objectTarget = item.get(sortKeyName()).getS();

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
@@ -1,8 +1,6 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
+/** A wrapper exception for problems with data model operations. */
 public class DataModelException extends RuntimeException {
   static final long serialVersionUID = 1L;
 

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
@@ -1,12 +1,12 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A Document Bucket document. Bundles context metadata and the data itself into a modeled object.
+ */
 public class DocumentBundle {
   private final PointerItem pointer;
   private final byte[] data;
@@ -16,22 +16,52 @@ public class DocumentBundle {
     this.data = Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data.
+   *
+   * @param data the data for this bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromData(byte[] data) {
     return fromDataAndContext(data, Collections.emptyMap());
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and pointer record.
+   *
+   * @param data the data for this bundle.
+   * @param pointer the item that tracks this record in the Document Bucket database.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndPointer(byte[] data, PointerItem pointer) {
     return new DocumentBundle(data, pointer);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and context.
+   *
+   * @param data the data for this bundle.
+   * @param context the context for this document bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndContext(byte[] data, Map<String, String> context) {
     return new DocumentBundle(data, PointerItem.generate(context));
   }
 
+  /**
+   * Get the data for this {@link DocumentBundle}.
+   *
+   * @return the associated data.
+   */
   public byte[] getData() {
     return Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Get the {@link PointerItem} for this Document Bucket bundle.
+   *
+   * @return the associated {@link PointerItem}.
+   */
   public PointerItem getPointer() {
     return pointer;
   }

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -13,6 +10,11 @@ import java.util.Map;
 import java.util.Set;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket pointer item. Pointer Items are DynamoDB items
+ * that maintain records of document items in the Document Bucket S3 bucket, and their associated
+ * metadata.
+ */
 public class PointerItem extends BaseItem {
   protected static final String TARGET =
       Config.contents.document_bucket.document_table.object_target;
@@ -32,6 +34,12 @@ public class PointerItem extends BaseItem {
     this.context = context;
   }
 
+  /**
+   * Helper to provide a DynamoDB condition filter to filter for only {@link PointerItem} records
+   * during scans.
+   *
+   * @return the filter for the scan operation.
+   */
   public static Map<String, Condition> filterFor() {
     Map<String, Condition> result = new HashMap<>(1);
     result.put(
@@ -42,14 +50,32 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Create a new pointer for a new Document Bucket document, with no associated context.
+   *
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate() {
     return generate(Collections.emptyMap());
   }
 
+  /**
+   * Create a new pointer for a Document Bucket document with the provided context.
+   *
+   * @param context the context for this document.
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate(Map<String, String> context) {
     return fromKeyAndContext(new UuidKey().toString(), context);
   }
 
+  /**
+   * Return a modeled {@link PointerItem} representing the associated pointer key and context.
+   *
+   * @param key the pointer key for this item.
+   * @param context the context for this document record.
+   * @return the {@link PointerItem} for this record.
+   */
   public static PointerItem fromKeyAndContext(String key, Map<String, String> context) {
     Map<String, AttributeValue> attributeContext = new HashMap<>(context.size());
 
@@ -60,6 +86,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(new UuidKey(key), attributeContext);
   }
 
+  /**
+   * Retrieve the context for this document item that this record points to.
+   *
+   * @return the context for this pointer's document.
+   */
   public Map<String, String> getContext() {
     Map<String, String> result = new HashMap<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {
@@ -75,11 +106,25 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(String key) {
     new UuidKey(key); // Check validity
     return atKey(new AttributeValue(key));
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(AttributeValue key) {
     Map<String, AttributeValue> result = new HashMap<>(2);
     result.put(partitionKeyName(), key);
@@ -87,6 +132,12 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link PointerItem}.
+   *
+   * @param item the modeled {@link PointerItem}.
+   * @return a {@link PointerItem} for the provided item contents.
+   */
   public static PointerItem fromItem(Map<String, AttributeValue> item) {
     UuidKey partitionKey = new UuidKey(item.remove(partitionKeyName()).getS());
     String sortKey = item.remove(sortKeyName()).getS();
@@ -97,6 +148,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(partitionKey, item);
   }
 
+  /**
+   * Retrieve the set of DynamoDB items for this pointer record's context keys.
+   *
+   * @return a {@link Set} of {@link ContextItem}s for each key in this pointer's context.
+   */
   public Set<ContextItem> contextItems() {
     HashSet<ContextItem> contextItems = new HashSet<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
@@ -1,10 +1,8 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.UUID;
 
+/** Models the unique key for identifying pointer items in S3 and DynamoDB. */
 public class UuidKey {
   private final UUID key;
 

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
@@ -1,0 +1,2 @@
+/** Objects that model the internal state and associations of the Document Bucket system. */
+package sfw.example.esdkworkshop.datamodel;

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/package-info.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The public-facing API and configuration resources for interacting with the Document Bucket
+ * system.
+ */
+package sfw.example.esdkworkshop;

--- a/exercises/java/add-esdk-start/Makefile
+++ b/exercises/java/add-esdk-start/Makefile
@@ -5,3 +5,7 @@ coverage:
 	cd ./target/site/jacoco/; python3 -m http.server &
 	elinks http://localhost:8000
 	killall python3
+
+javadoc:
+	mvn javadoc:javadoc
+	cd ./target/site/apidocs; python3 -m http.server

--- a/exercises/java/add-esdk-start/checkstyle.xml
+++ b/exercises/java/add-esdk-start/checkstyle.xml
@@ -23,7 +23,7 @@
     </module>
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->

--- a/exercises/java/add-esdk-start/pom.xml
+++ b/exercises/java/add-esdk-start/pom.xml
@@ -174,7 +174,7 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 // ADD-ESDK-START: Add the ESDK Dependency
@@ -24,6 +21,7 @@ import sfw.example.esdkworkshop.datamodel.ContextItem;
 import sfw.example.esdkworkshop.datamodel.DocumentBundle;
 import sfw.example.esdkworkshop.datamodel.PointerItem;
 
+/** Defines the public interface to the Document Bucket operations. */
 public class Api {
   private final AmazonDynamoDB ddbClient;
   private final AmazonS3 s3Client;
@@ -31,6 +29,14 @@ public class Api {
   private final String bucketName;
   // ADD-ESDK-START: Add the ESDK Dependency
 
+  /**
+   * Construct a Document Bucket {@code Api} using the provided configuration.
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   */
   public Api(
       // ADD-ESDK-START: Add the ESDK Dependency
       AmazonDynamoDB ddbClient, String tableName, AmazonS3 s3Client, String bucketName) {
@@ -41,22 +47,47 @@ public class Api {
     // ADD-ESDK-START: Add the ESDK Dependency
   }
 
+  /**
+   * Writes a {@link BaseItem} item to the DynamoDB table.
+   *
+   * @param modeledItem the item to write.
+   * @param <T> the subtype of item to write.
+   * @return the actual item value written ({@link Map} of {@link String}:{@link AttributeValue}).
+   */
   protected <T extends BaseItem> Map<String, AttributeValue> writeItem(T modeledItem) {
     Map<String, AttributeValue> ddbItem = modeledItem.toItem();
     ddbClient.putItem(tableName, ddbItem);
     return ddbItem;
   }
 
+  /**
+   * Retrieves a {@link PointerItem} for the supplied key.
+   *
+   * @param key the key for which to fetch the {@link PointerItem}.
+   * @return the {@link PointerItem} found.
+   */
   protected PointerItem getPointerItem(String key) {
     GetItemResult result = ddbClient.getItem(tableName, PointerItem.atKey(key));
     PointerItem pointer = PointerItem.fromItem(result.getItem());
     return pointer;
   }
 
+  /**
+   * Retrieves the {@link PointerItem} for an associated {@link ContextItem}-pointer pair.
+   *
+   * @param contextItem the {@link ContextItem} with the desired document pointer key.
+   * @return the {@link PointerItem} for that context and pointer pair.
+   */
   protected PointerItem getPointerItem(ContextItem contextItem) {
     return getPointerItem(contextItem.sortKey().getS());
   }
 
+  /**
+   * Query DynamoDB for the records associated with the supplied context key.
+   *
+   * @param contextKey the key for which to retrieve the list of matching records.
+   * @return the {@link Set} of {@link PointerItem}s that have that context key.
+   */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
     QueryResult result = ddbClient.query(ContextItem.queryFor(contextKey).withTableName(tableName));
     Set<ContextItem> contextItems =
@@ -66,6 +97,12 @@ public class Api {
     return pointerItems;
   }
 
+  /**
+   * Helper to perform the write operations required to store the provided {@link DocumentBundle} in
+   * the Document Bucket system.
+   *
+   * @param bundle the document to store.
+   */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setUserMetadata(bundle.getPointer().getContext());
@@ -76,8 +113,12 @@ public class Api {
         metadata);
   }
 
-  // TODO Return some kind of bundle so that data has been pulled from the stream
-  // but metadata is returned as well?
+  /**
+   * Retrieve the bytes associated with the key in S3.
+   *
+   * @param key the S3 key to retrieve.
+   * @return the bytes for that key.
+   */
   protected byte[] getObjectData(String key) {
     S3Object object = s3Client.getObject(bucketName, key);
     byte[] result;
@@ -89,6 +130,13 @@ public class Api {
     return result;
   }
 
+  /**
+   * Lists all of the Document Bucket {@link PointerItem}s in the DynamoDB table.
+   *
+   * <p>These correspond to documents in the Document Bucket.
+   *
+   * @return the {@link Set} of {@link PointerItem}s in the Document Bucket.
+   */
   public Set<PointerItem> list() {
     ScanResult result = ddbClient.scan(tableName, PointerItem.filterFor());
     Set<PointerItem> mappedItems =
@@ -96,10 +144,24 @@ public class Api {
     return mappedItems;
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket.
+   *
+   * @param data the data to store.
+   * @return the {@link PointerItem} under which this data is stored.
+   */
   public PointerItem store(byte[] data) {
     return store(data, Collections.emptyMap());
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket, along with the supplied
+   * Context.
+   *
+   * @param data the data to store.
+   * @param context the context for this data.
+   * @return the {@link PointerItem} under which this data and context are stored.
+   */
   public PointerItem store(byte[] data, Map<String, String> context) {
     // ADD-ESDK-START: Add Encryption to store
     DocumentBundle bundle = DocumentBundle.fromDataAndContext(data, context);
@@ -108,18 +170,46 @@ public class Api {
     return bundle.getPointer();
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key) {
     return retrieve(key, Collections.emptySet(), Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Set<String> expectedContextKeys) {
     return retrieve(key, expectedContextKeys, Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Map<String, String> expectedContext) {
     return retrieve(key, Collections.emptySet(), expectedContext);
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(
       String key, Set<String> expectedContextKeys, Map<String, String> expectedContext) {
     byte[] data = getObjectData(key);
@@ -129,6 +219,12 @@ public class Api {
     return DocumentBundle.fromDataAndPointer(data, pointer);
   }
 
+  /**
+   * Search the Document Bucket for any documents that have context with the supplied key.
+   *
+   * @param contextKey the key for which to search for matching documents.
+   * @return the {@link Set} of {@link PointerItem}s for matching documents.
+   */
   public Set<PointerItem> searchByContextKey(String contextKey) {
     return queryForContextKey(contextKey);
   }

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/App.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 // ADD-ESDK-START: Add the ESDK Dependency
@@ -9,11 +6,22 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
+/**
+ * Entry point for writing logic to work with the Document Bucket, with a helper to obtain an API
+ * instance to use.
+ */
 public class App {
 
   // The names of resources from the configuration file must exactly match those
   // keys for the automatic mapping.
   // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+  /**
+   * Obtain a Document Bucket API initialized with the resources as configured by the bootstrap
+   * configuration system.
+   *
+   * @return a new {@link Api} configured automatically by the bootstrapping system.
+   */
   public static Api initializeDocumentBucket() {
     // Load the TOML State file with the information about launched CloudFormation resources
     State state = new State(Config.contents.base.state_file);
@@ -31,6 +39,11 @@ public class App {
   }
   // CHECKSTYLE:ON AbbreviationAsWordInName
 
+  /**
+   * Entry point for writing logic to interact with the Document Bucket system.
+   *
+   * @param args the command-line arguments to the Document Bucket.
+   */
   public static void main(String[] args) {
     // Interact with the Document Bucket here or in jshell (mvn jshell:run)
   }

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Config.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Config.java
@@ -1,11 +1,9 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
+/** Helper to pull required Document Bucket configuration keys out of the configuration system. */
 public class Config {
   private static final File DEFAULT_CONFIG = new File("../../config.toml");
   public static final ConfigContents contents =
@@ -17,8 +15,12 @@ public class Config {
   // For automatic mpaping, these classes all have names dictated by the TOML file.
   // CHECKSTYLE:OFF MemberName
   // CHECKSTYLE:OFF ParameterName
+
+  /** The top-level contents of the configuration file. */
   public static class ConfigContents {
+    /** The [base] section of the configuration file. */
     public final Base base;
+    /** The [document_bucket] section of the configuration file. */
     public final DocumentBucket document_bucket;
 
     ConfigContents(Base base, DocumentBucket document_bucket) {
@@ -27,7 +29,9 @@ public class Config {
     }
   }
 
+  /** The [base] section of the configuration file. */
   public static class Base {
+    /** The location of the state file for CloudFormation-managed AWS resource identifiers. */
     public final String state_file;
 
     Base(String state_file) {
@@ -35,8 +39,11 @@ public class Config {
     }
   }
 
+  /** The [document_bucket] section of the configuration file. */
   public static class DocumentBucket {
+    /** The [document_bucket.document_table] section of the configuration file. */
     public final DocumentTable document_table;
+    /** The [document_bucket.bucket] section of the configuration file. */
     public final Bucket bucket;
 
     DocumentBucket(DocumentTable document_table, Bucket bucket) {
@@ -45,15 +52,24 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.document_table] section of the configuration file. */
   public static class DocumentTable {
+    /** Table name. */
     public final String name;
 
+    /** Table partition key name on items. */
     public final String partition_key;
 
+    /** Item sort key name on items. */
     public final String sort_key;
 
+    /** The identifier for pointer records indicating that this record is for an S3 object. */
     public final String object_target;
 
+    /**
+     * The prefix for context records to indicate that this record is for a list of documents
+     * matching a context key.
+     */
     public final String ctx_prefix;
 
     DocumentTable(
@@ -70,9 +86,13 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.bucket] section of the configuration file. */
   public static class Bucket {
+    /** Bucket name. */
     public final String name;
+    /** The identifier of the CloudFormation output. */
     public final String output;
+    /** The identifier of the CloudFormation export. */
     public final String export;
 
     Bucket(String name, String output, String export) {

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
@@ -1,5 +1,6 @@
 package sfw.example.esdkworkshop;
 
+/** Exception to wrap errors encountered during Document Bucket operations. */
 public class DocumentBucketException extends RuntimeException {
   public DocumentBucketException(String message, Throwable cause) {
     super(message, cause);

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/State.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/State.java
@@ -3,21 +3,36 @@ package sfw.example.esdkworkshop;
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
-// For automatic mpaping, these classes all have names dictated by the TOML file.
+// For automatic mapping, these classes all have names dictated by the TOML file.
 // CHECKSTYLE:OFF MemberName
 // CHECKSTYLE:OFF ParameterName
 // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+/**
+ * Helper to pull configuration of CloudFormation-managed AWS resources out of the generated state
+ * file.
+ */
 public class State {
   public final Contents contents;
 
+  /**
+   * Parse the state file at the provided path.
+   *
+   * @param path the path to the state file.
+   */
   public State(String path) {
     contents = new Toml().read(new File(path)).to(Contents.class);
   }
 
+  /** The top-level content structure of the state file. */
   public static class Contents {
+    /** The name of the Document Bucket S3 bucket. */
     public final String DocumentBucket;
+    /** The name of the Document Bucket DynamoDB table. */
     public final String DocumentTable;
+    /** The ARN of Faythe's CMK. */
     public final String FaytheCMK;
+    /** The ARN of Walter's CMK. */
     public final String WalterCMK;
 
     Contents(String DocumentBucket, String DocumentTable, String FaytheCMK, String WalterCMK) {

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -9,6 +6,11 @@ import java.util.Map;
 import java.util.Objects;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
+ * for items corresponding to key records for indexing items with a context key. See {@link
+ * PointerItem} for items corresponding to pointer records for documents.
+ */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;
   protected final AttributeValue sortKey;
@@ -22,6 +24,12 @@ public abstract class BaseItem {
     this.sortKey = new AttributeValue(sortKey);
   }
 
+  /**
+   * Transform this modeled item into a DynamoDB item ready to write to the table.
+   *
+   * @return the item in {@link Map} of ({@link String}, {@link AttributeValue}) pairs, ready to
+   *     write.
+   */
   public Map<String, AttributeValue> toItem() {
     Map<String, AttributeValue> item = new HashMap<>();
     item.put(PARTITION_KEY_NAME, partitionKey);
@@ -29,18 +37,38 @@ public abstract class BaseItem {
     return item;
   }
 
+  /**
+   * Return the name of the item attribute used as partition key.
+   *
+   * @return the partition key item attribute name.
+   */
   public static String partitionKeyName() {
     return PARTITION_KEY_NAME;
   }
 
+  /**
+   * Return the name of the item attribute used as sort key.
+   *
+   * @return the sort key item attribute name.
+   */
   public static String sortKeyName() {
     return SORT_KEY_NAME;
   }
 
+  /**
+   * Return the value of this item's partition key attribute.
+   *
+   * @return the value of the partition key attribute.
+   */
   public AttributeValue partitionKey() {
     return this.partitionKey;
   }
 
+  /**
+   * Return the value of this item's sort key attribute.
+   *
+   * @return the value of the sort key attribute.
+   */
   public AttributeValue sortKey() {
     return this.sortKey;
   }

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -10,6 +7,10 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import java.util.Map;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket context item. Context Items are DynamoDB items
+ * that maintain lists of which Document Bucket items have which metadata keys.
+ */
 public class ContextItem extends BaseItem {
   protected static final String PREFIX = Config.contents.document_bucket.document_table.ctx_prefix;
 
@@ -17,6 +18,12 @@ public class ContextItem extends BaseItem {
     super(contextKey, objectTarget.toString());
   }
 
+  /**
+   * Ensure that the provided key is in canonical form as a {@code ContextItem} partition key.
+   *
+   * @param key the key to canonicalize (if needed).
+   * @return a canonicalized {@code key}, if it was not already in canonical form.
+   */
   protected static String canonicalize(String key) {
     if (key.startsWith(PREFIX)) {
       return key;
@@ -24,6 +31,13 @@ public class ContextItem extends BaseItem {
     return PREFIX + key;
   }
 
+  /**
+   * Helper to build a DynamoDB {@link QueryRequest} for the provided context key. This query will
+   * return pointer records that have this context key in their context.
+   *
+   * @param contextKey the context key to search for.
+   * @return the {@link QueryRequest} to find matching records in DynamoDB.
+   */
   public static QueryRequest queryFor(String contextKey) {
     Condition keyIsContextKey =
         new Condition()
@@ -34,19 +48,46 @@ public class ContextItem extends BaseItem {
     return query;
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, String objectTarget) {
     UuidKey target = new UuidKey(objectTarget);
     return new ContextItem(canonicalize(key), target);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, UuidKey objectTarget) {
     return new ContextItem(canonicalize(key), objectTarget);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, AttributeValue objectTarget) {
     return fromContext(key, objectTarget.getS());
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link ContextItem}.
+   *
+   * @param item the modeled {@link ContextItem}.
+   * @return a {@link ContextItem} for the provided item contents.
+   */
   public static ContextItem fromItem(Map<String, AttributeValue> item) {
     String contextKey = item.get(partitionKeyName()).getS();
     String objectTarget = item.get(sortKeyName()).getS();

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
@@ -1,8 +1,6 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
+/** A wrapper exception for problems with data model operations. */
 public class DataModelException extends RuntimeException {
   static final long serialVersionUID = 1L;
 

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
@@ -1,12 +1,12 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A Document Bucket document. Bundles context metadata and the data itself into a modeled object.
+ */
 public class DocumentBundle {
   private final PointerItem pointer;
   private final byte[] data;
@@ -16,22 +16,52 @@ public class DocumentBundle {
     this.data = Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data.
+   *
+   * @param data the data for this bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromData(byte[] data) {
     return fromDataAndContext(data, Collections.emptyMap());
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and pointer record.
+   *
+   * @param data the data for this bundle.
+   * @param pointer the item that tracks this record in the Document Bucket database.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndPointer(byte[] data, PointerItem pointer) {
     return new DocumentBundle(data, pointer);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and context.
+   *
+   * @param data the data for this bundle.
+   * @param context the context for this document bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndContext(byte[] data, Map<String, String> context) {
     return new DocumentBundle(data, PointerItem.generate(context));
   }
 
+  /**
+   * Get the data for this {@link DocumentBundle}.
+   *
+   * @return the associated data.
+   */
   public byte[] getData() {
     return Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Get the {@link PointerItem} for this Document Bucket bundle.
+   *
+   * @return the associated {@link PointerItem}.
+   */
   public PointerItem getPointer() {
     return pointer;
   }

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -13,6 +10,11 @@ import java.util.Map;
 import java.util.Set;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket pointer item. Pointer Items are DynamoDB items
+ * that maintain records of document items in the Document Bucket S3 bucket, and their associated
+ * metadata.
+ */
 public class PointerItem extends BaseItem {
   protected static final String TARGET =
       Config.contents.document_bucket.document_table.object_target;
@@ -32,6 +34,12 @@ public class PointerItem extends BaseItem {
     this.context = context;
   }
 
+  /**
+   * Helper to provide a DynamoDB condition filter to filter for only {@link PointerItem} records
+   * during scans.
+   *
+   * @return the filter for the scan operation.
+   */
   public static Map<String, Condition> filterFor() {
     Map<String, Condition> result = new HashMap<>(1);
     result.put(
@@ -42,14 +50,32 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Create a new pointer for a new Document Bucket document, with no associated context.
+   *
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate() {
     return generate(Collections.emptyMap());
   }
 
+  /**
+   * Create a new pointer for a Document Bucket document with the provided context.
+   *
+   * @param context the context for this document.
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate(Map<String, String> context) {
     return fromKeyAndContext(new UuidKey().toString(), context);
   }
 
+  /**
+   * Return a modeled {@link PointerItem} representing the associated pointer key and context.
+   *
+   * @param key the pointer key for this item.
+   * @param context the context for this document record.
+   * @return the {@link PointerItem} for this record.
+   */
   public static PointerItem fromKeyAndContext(String key, Map<String, String> context) {
     Map<String, AttributeValue> attributeContext = new HashMap<>(context.size());
 
@@ -60,6 +86,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(new UuidKey(key), attributeContext);
   }
 
+  /**
+   * Retrieve the context for this document item that this record points to.
+   *
+   * @return the context for this pointer's document.
+   */
   public Map<String, String> getContext() {
     Map<String, String> result = new HashMap<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {
@@ -75,11 +106,25 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(String key) {
     new UuidKey(key); // Check validity
     return atKey(new AttributeValue(key));
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(AttributeValue key) {
     Map<String, AttributeValue> result = new HashMap<>(2);
     result.put(partitionKeyName(), key);
@@ -87,6 +132,12 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link PointerItem}.
+   *
+   * @param item the modeled {@link PointerItem}.
+   * @return a {@link PointerItem} for the provided item contents.
+   */
   public static PointerItem fromItem(Map<String, AttributeValue> item) {
     UuidKey partitionKey = new UuidKey(item.remove(partitionKeyName()).getS());
     String sortKey = item.remove(sortKeyName()).getS();
@@ -97,6 +148,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(partitionKey, item);
   }
 
+  /**
+   * Retrieve the set of DynamoDB items for this pointer record's context keys.
+   *
+   * @return a {@link Set} of {@link ContextItem}s for each key in this pointer's context.
+   */
   public Set<ContextItem> contextItems() {
     HashSet<ContextItem> contextItems = new HashSet<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
@@ -1,10 +1,8 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.UUID;
 
+/** Models the unique key for identifying pointer items in S3 and DynamoDB. */
 public class UuidKey {
   private final UUID key;
 

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
@@ -1,0 +1,2 @@
+/** Objects that model the internal state and associations of the Document Bucket system. */
+package sfw.example.esdkworkshop.datamodel;

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/package-info.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The public-facing API and configuration resources for interacting with the Document Bucket
+ * system.
+ */
+package sfw.example.esdkworkshop;

--- a/exercises/java/encryption-context-complete/Makefile
+++ b/exercises/java/encryption-context-complete/Makefile
@@ -5,3 +5,7 @@ coverage:
 	cd ./target/site/jacoco/; python3 -m http.server &
 	elinks http://localhost:8000
 	killall python3
+
+javadoc:
+	mvn javadoc:javadoc
+	cd ./target/site/apidocs; python3 -m http.server

--- a/exercises/java/encryption-context-complete/checkstyle.xml
+++ b/exercises/java/encryption-context-complete/checkstyle.xml
@@ -23,7 +23,7 @@
     </module>
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->

--- a/exercises/java/encryption-context-complete/pom.xml
+++ b/exercises/java/encryption-context-complete/pom.xml
@@ -174,7 +174,7 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
@@ -29,6 +26,7 @@ import sfw.example.esdkworkshop.datamodel.ContextItem;
 import sfw.example.esdkworkshop.datamodel.DocumentBundle;
 import sfw.example.esdkworkshop.datamodel.PointerItem;
 
+/** Defines the public interface to the Document Bucket operations. */
 public class Api {
   private final AmazonDynamoDB ddbClient;
   private final AmazonS3 s3Client;
@@ -37,6 +35,16 @@ public class Api {
   private final String tableName;
   private final String bucketName;
 
+  /**
+   * Construct a Document Bucket {@code Api} using a default {@link AwsCrypto} instance.
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   public Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -46,6 +54,19 @@ public class Api {
     this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
   }
 
+  /**
+   * Construct a Document Bucket {@code Api} using the provided {@link AwsCrypto} instance.
+   * (Included to facilitate unit testing.)
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param awsEncryptionSdk the {@link AwsCrypto} instance to use for Encryption and Decryption
+   *     operations.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   protected Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -61,22 +82,47 @@ public class Api {
     this.mkp = mkp;
   }
 
+  /**
+   * Writes a {@link BaseItem} item to the DynamoDB table.
+   *
+   * @param modeledItem the item to write.
+   * @param <T> the subtype of item to write.
+   * @return the actual item value written ({@link Map} of {@link String}:{@link AttributeValue}).
+   */
   protected <T extends BaseItem> Map<String, AttributeValue> writeItem(T modeledItem) {
     Map<String, AttributeValue> ddbItem = modeledItem.toItem();
     ddbClient.putItem(tableName, ddbItem);
     return ddbItem;
   }
 
+  /**
+   * Retrieves a {@link PointerItem} for the supplied key.
+   *
+   * @param key the key for which to fetch the {@link PointerItem}.
+   * @return the {@link PointerItem} found.
+   */
   protected PointerItem getPointerItem(String key) {
     GetItemResult result = ddbClient.getItem(tableName, PointerItem.atKey(key));
     PointerItem pointer = PointerItem.fromItem(result.getItem());
     return pointer;
   }
 
+  /**
+   * Retrieves the {@link PointerItem} for an associated {@link ContextItem}-pointer pair.
+   *
+   * @param contextItem the {@link ContextItem} with the desired document pointer key.
+   * @return the {@link PointerItem} for that context and pointer pair.
+   */
   protected PointerItem getPointerItem(ContextItem contextItem) {
     return getPointerItem(contextItem.sortKey().getS());
   }
 
+  /**
+   * Query DynamoDB for the records associated with the supplied context key.
+   *
+   * @param contextKey the key for which to retrieve the list of matching records.
+   * @return the {@link Set} of {@link PointerItem}s that have that context key.
+   */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
     QueryResult result = ddbClient.query(ContextItem.queryFor(contextKey).withTableName(tableName));
     Set<ContextItem> contextItems =
@@ -86,6 +132,12 @@ public class Api {
     return pointerItems;
   }
 
+  /**
+   * Helper to perform the write operations required to store the provided {@link DocumentBundle} in
+   * the Document Bucket system.
+   *
+   * @param bundle the document to store.
+   */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setUserMetadata(bundle.getPointer().getContext());
@@ -96,8 +148,12 @@ public class Api {
         metadata);
   }
 
-  // TODO Return some kind of bundle so that data has been pulled from the stream
-  // but metadata is returned as well?
+  /**
+   * Retrieve the bytes associated with the key in S3.
+   *
+   * @param key the S3 key to retrieve.
+   * @return the bytes for that key.
+   */
   protected byte[] getObjectData(String key) {
     S3Object object = s3Client.getObject(bucketName, key);
     byte[] result;
@@ -109,6 +165,13 @@ public class Api {
     return result;
   }
 
+  /**
+   * Lists all of the Document Bucket {@link PointerItem}s in the DynamoDB table.
+   *
+   * <p>These correspond to documents in the Document Bucket.
+   *
+   * @return the {@link Set} of {@link PointerItem}s in the Document Bucket.
+   */
   public Set<PointerItem> list() {
     ScanResult result = ddbClient.scan(tableName, PointerItem.filterFor());
     Set<PointerItem> mappedItems =
@@ -116,10 +179,24 @@ public class Api {
     return mappedItems;
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket.
+   *
+   * @param data the data to store.
+   * @return the {@link PointerItem} under which this data is stored.
+   */
   public PointerItem store(byte[] data) {
     return store(data, Collections.emptyMap());
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket, along with the supplied
+   * Context.
+   *
+   * @param data the data to store.
+   * @param context the context for this data.
+   * @return the {@link PointerItem} under which this data and context are stored.
+   */
   public PointerItem store(byte[] data, Map<String, String> context) {
     // ENCRYPTION-CONTEXT-COMPLETE: Set Encryption Context on Encrypt
     CryptoResult<byte[], KmsMasterKey> encryptedMessage =
@@ -131,18 +208,48 @@ public class Api {
     return bundle.getPointer();
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key) {
     return retrieve(key, Collections.emptySet(), Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys the keys expected to be present in the document's context.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Set<String> expectedContextKeys) {
     return retrieve(key, expectedContextKeys, Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContext the keys and associated values expected to be present in the document's
+   *     context.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Map<String, String> expectedContext) {
     return retrieve(key, Collections.emptySet(), expectedContext);
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys the keys expected to be present in the document's context.
+   * @param expectedContext the keys and associated values expected to be present in the document's
+   *     context.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(
       String key, Set<String> expectedContextKeys, Map<String, String> expectedContext) {
     byte[] data = getObjectData(key);
@@ -177,6 +284,12 @@ public class Api {
     return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
   }
 
+  /**
+   * Search the Document Bucket for any documents that have context with the supplied key.
+   *
+   * @param contextKey the key for which to search for matching documents.
+   * @return the {@link Set} of {@link PointerItem}s for matching documents.
+   */
   public Set<PointerItem> searchByContextKey(String contextKey) {
     return queryForContextKey(contextKey);
   }

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/App.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
@@ -9,11 +6,22 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
+/**
+ * Entry point for writing logic to work with the Document Bucket, with a helper to obtain an API
+ * instance to use.
+ */
 public class App {
 
   // The names of resources from the configuration file must exactly match those
   // keys for the automatic mapping.
   // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+  /**
+   * Obtain a Document Bucket API initialized with the resources as configured by the bootstrap
+   * configuration system.
+   *
+   * @return a new {@link Api} configured automatically by the bootstrapping system.
+   */
   public static Api initializeDocumentBucket() {
     // Load the TOML State file with the information about launched CloudFormation resources
     State state = new State(Config.contents.base.state_file);
@@ -38,6 +46,11 @@ public class App {
   }
   // CHECKSTYLE:ON AbbreviationAsWordInName
 
+  /**
+   * Entry point for writing logic to interact with the Document Bucket system.
+   *
+   * @param args the command-line arguments to the Document Bucket.
+   */
   public static void main(String[] args) {
     // Interact with the Document Bucket here or in jshell (mvn jshell:run)
   }

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Config.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Config.java
@@ -1,11 +1,9 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
+/** Helper to pull required Document Bucket configuration keys out of the configuration system. */
 public class Config {
   private static final File DEFAULT_CONFIG = new File("../../config.toml");
   public static final ConfigContents contents =
@@ -17,8 +15,12 @@ public class Config {
   // For automatic mpaping, these classes all have names dictated by the TOML file.
   // CHECKSTYLE:OFF MemberName
   // CHECKSTYLE:OFF ParameterName
+
+  /** The top-level contents of the configuration file. */
   public static class ConfigContents {
+    /** The [base] section of the configuration file. */
     public final Base base;
+    /** The [document_bucket] section of the configuration file. */
     public final DocumentBucket document_bucket;
 
     ConfigContents(Base base, DocumentBucket document_bucket) {
@@ -27,7 +29,9 @@ public class Config {
     }
   }
 
+  /** The [base] section of the configuration file. */
   public static class Base {
+    /** The location of the state file for CloudFormation-managed AWS resource identifiers. */
     public final String state_file;
 
     Base(String state_file) {
@@ -35,8 +39,11 @@ public class Config {
     }
   }
 
+  /** The [document_bucket] section of the configuration file. */
   public static class DocumentBucket {
+    /** The [document_bucket.document_table] section of the configuration file. */
     public final DocumentTable document_table;
+    /** The [document_bucket.bucket] section of the configuration file. */
     public final Bucket bucket;
 
     DocumentBucket(DocumentTable document_table, Bucket bucket) {
@@ -45,15 +52,24 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.document_table] section of the configuration file. */
   public static class DocumentTable {
+    /** Table name. */
     public final String name;
 
+    /** Table partition key name on items. */
     public final String partition_key;
 
+    /** Item sort key name on items. */
     public final String sort_key;
 
+    /** The identifier for pointer records indicating that this record is for an S3 object. */
     public final String object_target;
 
+    /**
+     * The prefix for context records to indicate that this record is for a list of documents
+     * matching a context key.
+     */
     public final String ctx_prefix;
 
     DocumentTable(
@@ -70,9 +86,13 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.bucket] section of the configuration file. */
   public static class Bucket {
+    /** Bucket name. */
     public final String name;
+    /** The identifier of the CloudFormation output. */
     public final String output;
+    /** The identifier of the CloudFormation export. */
     public final String export;
 
     Bucket(String name, String output, String export) {

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
@@ -1,5 +1,6 @@
 package sfw.example.esdkworkshop;
 
+/** Exception to wrap errors encountered during Document Bucket operations. */
 public class DocumentBucketException extends RuntimeException {
   public DocumentBucketException(String message, Throwable cause) {
     super(message, cause);

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/State.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/State.java
@@ -3,21 +3,36 @@ package sfw.example.esdkworkshop;
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
-// For automatic mpaping, these classes all have names dictated by the TOML file.
+// For automatic mapping, these classes all have names dictated by the TOML file.
 // CHECKSTYLE:OFF MemberName
 // CHECKSTYLE:OFF ParameterName
 // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+/**
+ * Helper to pull configuration of CloudFormation-managed AWS resources out of the generated state
+ * file.
+ */
 public class State {
   public final Contents contents;
 
+  /**
+   * Parse the state file at the provided path.
+   *
+   * @param path the path to the state file.
+   */
   public State(String path) {
     contents = new Toml().read(new File(path)).to(Contents.class);
   }
 
+  /** The top-level content structure of the state file. */
   public static class Contents {
+    /** The name of the Document Bucket S3 bucket. */
     public final String DocumentBucket;
+    /** The name of the Document Bucket DynamoDB table. */
     public final String DocumentTable;
+    /** The ARN of Faythe's CMK. */
     public final String FaytheCMK;
+    /** The ARN of Walter's CMK. */
     public final String WalterCMK;
 
     Contents(String DocumentBucket, String DocumentTable, String FaytheCMK, String WalterCMK) {

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -9,6 +6,11 @@ import java.util.Map;
 import java.util.Objects;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
+ * for items corresponding to key records for indexing items with a context key. See
+ * {@link PointerItem} for items corresponding to pointer records for documents.
+ */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;
   protected final AttributeValue sortKey;
@@ -22,6 +24,12 @@ public abstract class BaseItem {
     this.sortKey = new AttributeValue(sortKey);
   }
 
+  /**
+   * Transform this modeled item into a DynamoDB item ready to write to the table.
+   *
+   * @return the item in {@link Map} of ({@link String}, {@link AttributeValue}) pairs, ready to
+   *     write.
+   */
   public Map<String, AttributeValue> toItem() {
     Map<String, AttributeValue> item = new HashMap<>();
     item.put(PARTITION_KEY_NAME, partitionKey);
@@ -29,18 +37,38 @@ public abstract class BaseItem {
     return item;
   }
 
+  /**
+   * Return the name of the item attribute used as partition key.
+   *
+   * @return the partition key item attribute name.
+   */
   public static String partitionKeyName() {
     return PARTITION_KEY_NAME;
   }
 
+  /**
+   * Return the name of the item attribute used as sort key.
+   *
+   * @return the sort key item attribute name.
+   */
   public static String sortKeyName() {
     return SORT_KEY_NAME;
   }
 
+  /**
+   * Return the value of this item's partition key attribute.
+   *
+   * @return the value of the partition key attribute.
+   */
   public AttributeValue partitionKey() {
     return this.partitionKey;
   }
 
+  /**
+   * Return the value of this item's sort key attribute.
+   *
+   * @return the value of the sort key attribute.
+   */
   public AttributeValue sortKey() {
     return this.sortKey;
   }

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -8,8 +8,8 @@ import sfw.example.esdkworkshop.Config;
 
 /**
  * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
- * for items corresponding to key records for indexing items with a context key. See
- * {@link PointerItem} for items corresponding to pointer records for documents.
+ * for items corresponding to key records for indexing items with a context key. See {@link
+ * PointerItem} for items corresponding to pointer records for documents.
  */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -10,6 +7,10 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import java.util.Map;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket context item. Context Items are DynamoDB items
+ * that maintain lists of which Document Bucket items have which metadata keys.
+ */
 public class ContextItem extends BaseItem {
   protected static final String PREFIX = Config.contents.document_bucket.document_table.ctx_prefix;
 
@@ -17,6 +18,12 @@ public class ContextItem extends BaseItem {
     super(contextKey, objectTarget.toString());
   }
 
+  /**
+   * Ensure that the provided key is in canonical form as a {@code ContextItem} partition key.
+   *
+   * @param key the key to canonicalize (if needed).
+   * @return a canonicalized {@code key}, if it was not already in canonical form.
+   */
   protected static String canonicalize(String key) {
     if (key.startsWith(PREFIX)) {
       return key;
@@ -24,6 +31,13 @@ public class ContextItem extends BaseItem {
     return PREFIX + key;
   }
 
+  /**
+   * Helper to build a DynamoDB {@link QueryRequest} for the provided context key. This query will
+   * return pointer records that have this context key in their context.
+   *
+   * @param contextKey the context key to search for.
+   * @return the {@link QueryRequest} to find matching records in DynamoDB.
+   */
   public static QueryRequest queryFor(String contextKey) {
     Condition keyIsContextKey =
         new Condition()
@@ -34,19 +48,46 @@ public class ContextItem extends BaseItem {
     return query;
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, String objectTarget) {
     UuidKey target = new UuidKey(objectTarget);
     return new ContextItem(canonicalize(key), target);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, UuidKey objectTarget) {
     return new ContextItem(canonicalize(key), objectTarget);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, AttributeValue objectTarget) {
     return fromContext(key, objectTarget.getS());
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link ContextItem}.
+   *
+   * @param item the modeled {@link ContextItem}.
+   * @return a {@link ContextItem} for the provided item contents.
+   */
   public static ContextItem fromItem(Map<String, AttributeValue> item) {
     String contextKey = item.get(partitionKeyName()).getS();
     String objectTarget = item.get(sortKeyName()).getS();

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
@@ -1,8 +1,6 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
+/** A wrapper exception for problems with data model operations. */
 public class DataModelException extends RuntimeException {
   static final long serialVersionUID = 1L;
 

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
@@ -1,12 +1,12 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A Document Bucket document. Bundles context metadata and the data itself into a modeled object.
+ */
 public class DocumentBundle {
   private final PointerItem pointer;
   private final byte[] data;
@@ -16,22 +16,52 @@ public class DocumentBundle {
     this.data = Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data.
+   *
+   * @param data the data for this bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromData(byte[] data) {
     return fromDataAndContext(data, Collections.emptyMap());
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and pointer record.
+   *
+   * @param data the data for this bundle.
+   * @param pointer the item that tracks this record in the Document Bucket database.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndPointer(byte[] data, PointerItem pointer) {
     return new DocumentBundle(data, pointer);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and context.
+   *
+   * @param data the data for this bundle.
+   * @param context the context for this document bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndContext(byte[] data, Map<String, String> context) {
     return new DocumentBundle(data, PointerItem.generate(context));
   }
 
+  /**
+   * Get the data for this {@link DocumentBundle}.
+   *
+   * @return the associated data.
+   */
   public byte[] getData() {
     return Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Get the {@link PointerItem} for this Document Bucket bundle.
+   *
+   * @return the associated {@link PointerItem}.
+   */
   public PointerItem getPointer() {
     return pointer;
   }

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -13,6 +10,11 @@ import java.util.Map;
 import java.util.Set;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket pointer item. Pointer Items are DynamoDB items
+ * that maintain records of document items in the Document Bucket S3 bucket, and their associated
+ * metadata.
+ */
 public class PointerItem extends BaseItem {
   protected static final String TARGET =
       Config.contents.document_bucket.document_table.object_target;
@@ -32,6 +34,12 @@ public class PointerItem extends BaseItem {
     this.context = context;
   }
 
+  /**
+   * Helper to provide a DynamoDB condition filter to filter for only {@link PointerItem} records
+   * during scans.
+   *
+   * @return the filter for the scan operation.
+   */
   public static Map<String, Condition> filterFor() {
     Map<String, Condition> result = new HashMap<>(1);
     result.put(
@@ -42,14 +50,32 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Create a new pointer for a new Document Bucket document, with no associated context.
+   *
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate() {
     return generate(Collections.emptyMap());
   }
 
+  /**
+   * Create a new pointer for a Document Bucket document with the provided context.
+   *
+   * @param context the context for this document.
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate(Map<String, String> context) {
     return fromKeyAndContext(new UuidKey().toString(), context);
   }
 
+  /**
+   * Return a modeled {@link PointerItem} representing the associated pointer key and context.
+   *
+   * @param key the pointer key for this item.
+   * @param context the context for this document record.
+   * @return the {@link PointerItem} for this record.
+   */
   public static PointerItem fromKeyAndContext(String key, Map<String, String> context) {
     Map<String, AttributeValue> attributeContext = new HashMap<>(context.size());
 
@@ -60,6 +86,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(new UuidKey(key), attributeContext);
   }
 
+  /**
+   * Retrieve the context for this document item that this record points to.
+   *
+   * @return the context for this pointer's document.
+   */
   public Map<String, String> getContext() {
     Map<String, String> result = new HashMap<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {
@@ -75,11 +106,25 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(String key) {
     new UuidKey(key); // Check validity
     return atKey(new AttributeValue(key));
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(AttributeValue key) {
     Map<String, AttributeValue> result = new HashMap<>(2);
     result.put(partitionKeyName(), key);
@@ -87,6 +132,12 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link PointerItem}.
+   *
+   * @param item the modeled {@link PointerItem}.
+   * @return a {@link PointerItem} for the provided item contents.
+   */
   public static PointerItem fromItem(Map<String, AttributeValue> item) {
     UuidKey partitionKey = new UuidKey(item.remove(partitionKeyName()).getS());
     String sortKey = item.remove(sortKeyName()).getS();
@@ -97,6 +148,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(partitionKey, item);
   }
 
+  /**
+   * Retrieve the set of DynamoDB items for this pointer record's context keys.
+   *
+   * @return a {@link Set} of {@link ContextItem}s for each key in this pointer's context.
+   */
   public Set<ContextItem> contextItems() {
     HashSet<ContextItem> contextItems = new HashSet<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
@@ -1,10 +1,8 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.UUID;
 
+/** Models the unique key for identifying pointer items in S3 and DynamoDB. */
 public class UuidKey {
   private final UUID key;
 

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
@@ -1,0 +1,2 @@
+/** Objects that model the internal state and associations of the Document Bucket system. */
+package sfw.example.esdkworkshop.datamodel;

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/package-info.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The public-facing API and configuration resources for interacting with the Document Bucket
+ * system.
+ */
+package sfw.example.esdkworkshop;

--- a/exercises/java/encryption-context-start/Makefile
+++ b/exercises/java/encryption-context-start/Makefile
@@ -5,3 +5,7 @@ coverage:
 	cd ./target/site/jacoco/; python3 -m http.server &
 	elinks http://localhost:8000
 	killall python3
+
+javadoc:
+	mvn javadoc:javadoc
+	cd ./target/site/apidocs; python3 -m http.server

--- a/exercises/java/encryption-context-start/checkstyle.xml
+++ b/exercises/java/encryption-context-start/checkstyle.xml
@@ -23,7 +23,7 @@
     </module>
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->

--- a/exercises/java/encryption-context-start/pom.xml
+++ b/exercises/java/encryption-context-start/pom.xml
@@ -174,7 +174,7 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -18,7 +18,6 @@ import com.amazonaws.util.IOUtils;
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import sfw.example.esdkworkshop.datamodel.BaseItem;

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
@@ -21,6 +18,7 @@ import com.amazonaws.util.IOUtils;
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import sfw.example.esdkworkshop.datamodel.BaseItem;
@@ -28,6 +26,7 @@ import sfw.example.esdkworkshop.datamodel.ContextItem;
 import sfw.example.esdkworkshop.datamodel.DocumentBundle;
 import sfw.example.esdkworkshop.datamodel.PointerItem;
 
+/** Defines the public interface to the Document Bucket operations. */
 public class Api {
   private final AmazonDynamoDB ddbClient;
   private final AmazonS3 s3Client;
@@ -36,6 +35,16 @@ public class Api {
   private final String tableName;
   private final String bucketName;
 
+  /**
+   * Construct a Document Bucket {@code Api} using a default {@link AwsCrypto} instance.
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   public Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -45,6 +54,19 @@ public class Api {
     this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
   }
 
+  /**
+   * Construct a Document Bucket {@code Api} using the provided {@link AwsCrypto} instance.
+   * (Included to facilitate unit testing.)
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param awsEncryptionSdk the {@link AwsCrypto} instance to use for Encryption and Decryption
+   *     operations.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   protected Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -60,22 +82,47 @@ public class Api {
     this.mkp = mkp;
   }
 
+  /**
+   * Writes a {@link BaseItem} item to the DynamoDB table.
+   *
+   * @param modeledItem the item to write.
+   * @param <T> the subtype of item to write.
+   * @return the actual item value written ({@link Map} of {@link String}:{@link AttributeValue}).
+   */
   protected <T extends BaseItem> Map<String, AttributeValue> writeItem(T modeledItem) {
     Map<String, AttributeValue> ddbItem = modeledItem.toItem();
     ddbClient.putItem(tableName, ddbItem);
     return ddbItem;
   }
 
+  /**
+   * Retrieves a {@link PointerItem} for the supplied key.
+   *
+   * @param key the key for which to fetch the {@link PointerItem}.
+   * @return the {@link PointerItem} found.
+   */
   protected PointerItem getPointerItem(String key) {
     GetItemResult result = ddbClient.getItem(tableName, PointerItem.atKey(key));
     PointerItem pointer = PointerItem.fromItem(result.getItem());
     return pointer;
   }
 
+  /**
+   * Retrieves the {@link PointerItem} for an associated {@link ContextItem}-pointer pair.
+   *
+   * @param contextItem the {@link ContextItem} with the desired document pointer key.
+   * @return the {@link PointerItem} for that context and pointer pair.
+   */
   protected PointerItem getPointerItem(ContextItem contextItem) {
     return getPointerItem(contextItem.sortKey().getS());
   }
 
+  /**
+   * Query DynamoDB for the records associated with the supplied context key.
+   *
+   * @param contextKey the key for which to retrieve the list of matching records.
+   * @return the {@link Set} of {@link PointerItem}s that have that context key.
+   */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
     QueryResult result = ddbClient.query(ContextItem.queryFor(contextKey).withTableName(tableName));
     Set<ContextItem> contextItems =
@@ -85,6 +132,12 @@ public class Api {
     return pointerItems;
   }
 
+  /**
+   * Helper to perform the write operations required to store the provided {@link DocumentBundle} in
+   * the Document Bucket system.
+   *
+   * @param bundle the document to store.
+   */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setUserMetadata(bundle.getPointer().getContext());
@@ -95,8 +148,12 @@ public class Api {
         metadata);
   }
 
-  // TODO Return some kind of bundle so that data has been pulled from the stream
-  // but metadata is returned as well?
+  /**
+   * Retrieve the bytes associated with the key in S3.
+   *
+   * @param key the S3 key to retrieve.
+   * @return the bytes for that key.
+   */
   protected byte[] getObjectData(String key) {
     S3Object object = s3Client.getObject(bucketName, key);
     byte[] result;
@@ -108,6 +165,13 @@ public class Api {
     return result;
   }
 
+  /**
+   * Lists all of the Document Bucket {@link PointerItem}s in the DynamoDB table.
+   *
+   * <p>These correspond to documents in the Document Bucket.
+   *
+   * @return the {@link Set} of {@link PointerItem}s in the Document Bucket.
+   */
   public Set<PointerItem> list() {
     ScanResult result = ddbClient.scan(tableName, PointerItem.filterFor());
     Set<PointerItem> mappedItems =
@@ -115,10 +179,24 @@ public class Api {
     return mappedItems;
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket.
+   *
+   * @param data the data to store.
+   * @return the {@link PointerItem} under which this data is stored.
+   */
   public PointerItem store(byte[] data) {
     return store(data, Collections.emptyMap());
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket, along with the supplied
+   * Context.
+   *
+   * @param data the data to store.
+   * @param context the context for this data.
+   * @return the {@link PointerItem} under which this data and context are stored.
+   */
   public PointerItem store(byte[] data, Map<String, String> context) {
     // ENCRYPTION-CONTEXT-START: Set Encryption Context on Encrypt
     CryptoResult<byte[], KmsMasterKey> encryptedMessage = awsEncryptionSdk.encryptData(mkp, data);
@@ -129,18 +207,46 @@ public class Api {
     return bundle.getPointer();
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key) {
     return retrieve(key, Collections.emptySet(), Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Set<String> expectedContextKeys) {
     return retrieve(key, expectedContextKeys, Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Map<String, String> expectedContext) {
     return retrieve(key, Collections.emptySet(), expectedContext);
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(
       String key, Set<String> expectedContextKeys, Map<String, String> expectedContext) {
     byte[] data = getObjectData(key);
@@ -151,6 +257,12 @@ public class Api {
     return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
   }
 
+  /**
+   * Search the Document Bucket for any documents that have context with the supplied key.
+   *
+   * @param contextKey the key for which to search for matching documents.
+   * @return the {@link Set} of {@link PointerItem}s for matching documents.
+   */
   public Set<PointerItem> searchByContextKey(String contextKey) {
     return queryForContextKey(contextKey);
   }

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/App.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
@@ -9,11 +6,22 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
+/**
+ * Entry point for writing logic to work with the Document Bucket, with a helper to obtain an API
+ * instance to use.
+ */
 public class App {
 
   // The names of resources from the configuration file must exactly match those
   // keys for the automatic mapping.
   // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+  /**
+   * Obtain a Document Bucket API initialized with the resources as configured by the bootstrap
+   * configuration system.
+   *
+   * @return a new {@link Api} configured automatically by the bootstrapping system.
+   */
   public static Api initializeDocumentBucket() {
     // Load the TOML State file with the information about launched CloudFormation resources
     State state = new State(Config.contents.base.state_file);
@@ -38,6 +46,11 @@ public class App {
   }
   // CHECKSTYLE:ON AbbreviationAsWordInName
 
+  /**
+   * Entry point for writing logic to interact with the Document Bucket system.
+   *
+   * @param args the command-line arguments to the Document Bucket.
+   */
   public static void main(String[] args) {
     // Interact with the Document Bucket here or in jshell (mvn jshell:run)
   }

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Config.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Config.java
@@ -1,11 +1,9 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
+/** Helper to pull required Document Bucket configuration keys out of the configuration system. */
 public class Config {
   private static final File DEFAULT_CONFIG = new File("../../config.toml");
   public static final ConfigContents contents =
@@ -17,8 +15,12 @@ public class Config {
   // For automatic mpaping, these classes all have names dictated by the TOML file.
   // CHECKSTYLE:OFF MemberName
   // CHECKSTYLE:OFF ParameterName
+
+  /** The top-level contents of the configuration file. */
   public static class ConfigContents {
+    /** The [base] section of the configuration file. */
     public final Base base;
+    /** The [document_bucket] section of the configuration file. */
     public final DocumentBucket document_bucket;
 
     ConfigContents(Base base, DocumentBucket document_bucket) {
@@ -27,7 +29,9 @@ public class Config {
     }
   }
 
+  /** The [base] section of the configuration file. */
   public static class Base {
+    /** The location of the state file for CloudFormation-managed AWS resource identifiers. */
     public final String state_file;
 
     Base(String state_file) {
@@ -35,8 +39,11 @@ public class Config {
     }
   }
 
+  /** The [document_bucket] section of the configuration file. */
   public static class DocumentBucket {
+    /** The [document_bucket.document_table] section of the configuration file. */
     public final DocumentTable document_table;
+    /** The [document_bucket.bucket] section of the configuration file. */
     public final Bucket bucket;
 
     DocumentBucket(DocumentTable document_table, Bucket bucket) {
@@ -45,15 +52,24 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.document_table] section of the configuration file. */
   public static class DocumentTable {
+    /** Table name. */
     public final String name;
 
+    /** Table partition key name on items. */
     public final String partition_key;
 
+    /** Item sort key name on items. */
     public final String sort_key;
 
+    /** The identifier for pointer records indicating that this record is for an S3 object. */
     public final String object_target;
 
+    /**
+     * The prefix for context records to indicate that this record is for a list of documents
+     * matching a context key.
+     */
     public final String ctx_prefix;
 
     DocumentTable(
@@ -70,9 +86,13 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.bucket] section of the configuration file. */
   public static class Bucket {
+    /** Bucket name. */
     public final String name;
+    /** The identifier of the CloudFormation output. */
     public final String output;
+    /** The identifier of the CloudFormation export. */
     public final String export;
 
     Bucket(String name, String output, String export) {

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
@@ -1,5 +1,6 @@
 package sfw.example.esdkworkshop;
 
+/** Exception to wrap errors encountered during Document Bucket operations. */
 public class DocumentBucketException extends RuntimeException {
   public DocumentBucketException(String message, Throwable cause) {
     super(message, cause);

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/State.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/State.java
@@ -3,21 +3,36 @@ package sfw.example.esdkworkshop;
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
-// For automatic mpaping, these classes all have names dictated by the TOML file.
+// For automatic mapping, these classes all have names dictated by the TOML file.
 // CHECKSTYLE:OFF MemberName
 // CHECKSTYLE:OFF ParameterName
 // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+/**
+ * Helper to pull configuration of CloudFormation-managed AWS resources out of the generated state
+ * file.
+ */
 public class State {
   public final Contents contents;
 
+  /**
+   * Parse the state file at the provided path.
+   *
+   * @param path the path to the state file.
+   */
   public State(String path) {
     contents = new Toml().read(new File(path)).to(Contents.class);
   }
 
+  /** The top-level content structure of the state file. */
   public static class Contents {
+    /** The name of the Document Bucket S3 bucket. */
     public final String DocumentBucket;
+    /** The name of the Document Bucket DynamoDB table. */
     public final String DocumentTable;
+    /** The ARN of Faythe's CMK. */
     public final String FaytheCMK;
+    /** The ARN of Walter's CMK. */
     public final String WalterCMK;
 
     Contents(String DocumentBucket, String DocumentTable, String FaytheCMK, String WalterCMK) {

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -9,6 +6,11 @@ import java.util.Map;
 import java.util.Objects;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
+ * for items corresponding to key records for indexing items with a context key. See
+ * {@link PointerItem} for items corresponding to pointer records for documents.
+ */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;
   protected final AttributeValue sortKey;
@@ -22,6 +24,12 @@ public abstract class BaseItem {
     this.sortKey = new AttributeValue(sortKey);
   }
 
+  /**
+   * Transform this modeled item into a DynamoDB item ready to write to the table.
+   *
+   * @return the item in {@link Map} of ({@link String}, {@link AttributeValue}) pairs, ready to
+   *     write.
+   */
   public Map<String, AttributeValue> toItem() {
     Map<String, AttributeValue> item = new HashMap<>();
     item.put(PARTITION_KEY_NAME, partitionKey);
@@ -29,18 +37,38 @@ public abstract class BaseItem {
     return item;
   }
 
+  /**
+   * Return the name of the item attribute used as partition key.
+   *
+   * @return the partition key item attribute name.
+   */
   public static String partitionKeyName() {
     return PARTITION_KEY_NAME;
   }
 
+  /**
+   * Return the name of the item attribute used as sort key.
+   *
+   * @return the sort key item attribute name.
+   */
   public static String sortKeyName() {
     return SORT_KEY_NAME;
   }
 
+  /**
+   * Return the value of this item's partition key attribute.
+   *
+   * @return the value of the partition key attribute.
+   */
   public AttributeValue partitionKey() {
     return this.partitionKey;
   }
 
+  /**
+   * Return the value of this item's sort key attribute.
+   *
+   * @return the value of the sort key attribute.
+   */
   public AttributeValue sortKey() {
     return this.sortKey;
   }

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -8,8 +8,8 @@ import sfw.example.esdkworkshop.Config;
 
 /**
  * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
- * for items corresponding to key records for indexing items with a context key. See
- * {@link PointerItem} for items corresponding to pointer records for documents.
+ * for items corresponding to key records for indexing items with a context key. See {@link
+ * PointerItem} for items corresponding to pointer records for documents.
  */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -10,6 +7,10 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import java.util.Map;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket context item. Context Items are DynamoDB items
+ * that maintain lists of which Document Bucket items have which metadata keys.
+ */
 public class ContextItem extends BaseItem {
   protected static final String PREFIX = Config.contents.document_bucket.document_table.ctx_prefix;
 
@@ -17,6 +18,12 @@ public class ContextItem extends BaseItem {
     super(contextKey, objectTarget.toString());
   }
 
+  /**
+   * Ensure that the provided key is in canonical form as a {@code ContextItem} partition key.
+   *
+   * @param key the key to canonicalize (if needed).
+   * @return a canonicalized {@code key}, if it was not already in canonical form.
+   */
   protected static String canonicalize(String key) {
     if (key.startsWith(PREFIX)) {
       return key;
@@ -24,6 +31,13 @@ public class ContextItem extends BaseItem {
     return PREFIX + key;
   }
 
+  /**
+   * Helper to build a DynamoDB {@link QueryRequest} for the provided context key. This query will
+   * return pointer records that have this context key in their context.
+   *
+   * @param contextKey the context key to search for.
+   * @return the {@link QueryRequest} to find matching records in DynamoDB.
+   */
   public static QueryRequest queryFor(String contextKey) {
     Condition keyIsContextKey =
         new Condition()
@@ -34,19 +48,46 @@ public class ContextItem extends BaseItem {
     return query;
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, String objectTarget) {
     UuidKey target = new UuidKey(objectTarget);
     return new ContextItem(canonicalize(key), target);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, UuidKey objectTarget) {
     return new ContextItem(canonicalize(key), objectTarget);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, AttributeValue objectTarget) {
     return fromContext(key, objectTarget.getS());
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link ContextItem}.
+   *
+   * @param item the modeled {@link ContextItem}.
+   * @return a {@link ContextItem} for the provided item contents.
+   */
   public static ContextItem fromItem(Map<String, AttributeValue> item) {
     String contextKey = item.get(partitionKeyName()).getS();
     String objectTarget = item.get(sortKeyName()).getS();

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
@@ -1,8 +1,6 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
+/** A wrapper exception for problems with data model operations. */
 public class DataModelException extends RuntimeException {
   static final long serialVersionUID = 1L;
 

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
@@ -1,12 +1,12 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A Document Bucket document. Bundles context metadata and the data itself into a modeled object.
+ */
 public class DocumentBundle {
   private final PointerItem pointer;
   private final byte[] data;
@@ -16,22 +16,52 @@ public class DocumentBundle {
     this.data = Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data.
+   *
+   * @param data the data for this bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromData(byte[] data) {
     return fromDataAndContext(data, Collections.emptyMap());
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and pointer record.
+   *
+   * @param data the data for this bundle.
+   * @param pointer the item that tracks this record in the Document Bucket database.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndPointer(byte[] data, PointerItem pointer) {
     return new DocumentBundle(data, pointer);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and context.
+   *
+   * @param data the data for this bundle.
+   * @param context the context for this document bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndContext(byte[] data, Map<String, String> context) {
     return new DocumentBundle(data, PointerItem.generate(context));
   }
 
+  /**
+   * Get the data for this {@link DocumentBundle}.
+   *
+   * @return the associated data.
+   */
   public byte[] getData() {
     return Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Get the {@link PointerItem} for this Document Bucket bundle.
+   *
+   * @return the associated {@link PointerItem}.
+   */
   public PointerItem getPointer() {
     return pointer;
   }

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -13,6 +10,11 @@ import java.util.Map;
 import java.util.Set;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket pointer item. Pointer Items are DynamoDB items
+ * that maintain records of document items in the Document Bucket S3 bucket, and their associated
+ * metadata.
+ */
 public class PointerItem extends BaseItem {
   protected static final String TARGET =
       Config.contents.document_bucket.document_table.object_target;
@@ -32,6 +34,12 @@ public class PointerItem extends BaseItem {
     this.context = context;
   }
 
+  /**
+   * Helper to provide a DynamoDB condition filter to filter for only {@link PointerItem} records
+   * during scans.
+   *
+   * @return the filter for the scan operation.
+   */
   public static Map<String, Condition> filterFor() {
     Map<String, Condition> result = new HashMap<>(1);
     result.put(
@@ -42,14 +50,32 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Create a new pointer for a new Document Bucket document, with no associated context.
+   *
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate() {
     return generate(Collections.emptyMap());
   }
 
+  /**
+   * Create a new pointer for a Document Bucket document with the provided context.
+   *
+   * @param context the context for this document.
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate(Map<String, String> context) {
     return fromKeyAndContext(new UuidKey().toString(), context);
   }
 
+  /**
+   * Return a modeled {@link PointerItem} representing the associated pointer key and context.
+   *
+   * @param key the pointer key for this item.
+   * @param context the context for this document record.
+   * @return the {@link PointerItem} for this record.
+   */
   public static PointerItem fromKeyAndContext(String key, Map<String, String> context) {
     Map<String, AttributeValue> attributeContext = new HashMap<>(context.size());
 
@@ -60,6 +86,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(new UuidKey(key), attributeContext);
   }
 
+  /**
+   * Retrieve the context for this document item that this record points to.
+   *
+   * @return the context for this pointer's document.
+   */
   public Map<String, String> getContext() {
     Map<String, String> result = new HashMap<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {
@@ -75,11 +106,25 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(String key) {
     new UuidKey(key); // Check validity
     return atKey(new AttributeValue(key));
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(AttributeValue key) {
     Map<String, AttributeValue> result = new HashMap<>(2);
     result.put(partitionKeyName(), key);
@@ -87,6 +132,12 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link PointerItem}.
+   *
+   * @param item the modeled {@link PointerItem}.
+   * @return a {@link PointerItem} for the provided item contents.
+   */
   public static PointerItem fromItem(Map<String, AttributeValue> item) {
     UuidKey partitionKey = new UuidKey(item.remove(partitionKeyName()).getS());
     String sortKey = item.remove(sortKeyName()).getS();
@@ -97,6 +148,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(partitionKey, item);
   }
 
+  /**
+   * Retrieve the set of DynamoDB items for this pointer record's context keys.
+   *
+   * @return a {@link Set} of {@link ContextItem}s for each key in this pointer's context.
+   */
   public Set<ContextItem> contextItems() {
     HashSet<ContextItem> contextItems = new HashSet<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
@@ -1,10 +1,8 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.UUID;
 
+/** Models the unique key for identifying pointer items in S3 and DynamoDB. */
 public class UuidKey {
   private final UUID key;
 

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
@@ -1,0 +1,2 @@
+/** Objects that model the internal state and associations of the Document Bucket system. */
+package sfw.example.esdkworkshop.datamodel;

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/package-info.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The public-facing API and configuration resources for interacting with the Document Bucket
+ * system.
+ */
+package sfw.example.esdkworkshop;

--- a/exercises/java/multi-cmk-complete/Makefile
+++ b/exercises/java/multi-cmk-complete/Makefile
@@ -5,3 +5,7 @@ coverage:
 	cd ./target/site/jacoco/; python3 -m http.server &
 	elinks http://localhost:8000
 	killall python3
+
+javadoc:
+	mvn javadoc:javadoc
+	cd ./target/site/apidocs; python3 -m http.server

--- a/exercises/java/multi-cmk-complete/checkstyle.xml
+++ b/exercises/java/multi-cmk-complete/checkstyle.xml
@@ -23,7 +23,7 @@
     </module>
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->

--- a/exercises/java/multi-cmk-complete/pom.xml
+++ b/exercises/java/multi-cmk-complete/pom.xml
@@ -174,7 +174,7 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
@@ -28,6 +25,7 @@ import sfw.example.esdkworkshop.datamodel.ContextItem;
 import sfw.example.esdkworkshop.datamodel.DocumentBundle;
 import sfw.example.esdkworkshop.datamodel.PointerItem;
 
+/** Defines the public interface to the Document Bucket operations. */
 public class Api {
   private final AmazonDynamoDB ddbClient;
   private final AmazonS3 s3Client;
@@ -36,6 +34,16 @@ public class Api {
   private final String tableName;
   private final String bucketName;
 
+  /**
+   * Construct a Document Bucket {@code Api} using a default {@link AwsCrypto} instance.
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   public Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -45,6 +53,19 @@ public class Api {
     this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
   }
 
+  /**
+   * Construct a Document Bucket {@code Api} using the provided {@link AwsCrypto} instance.
+   * (Included to facilitate unit testing.)
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param awsEncryptionSdk the {@link AwsCrypto} instance to use for Encryption and Decryption
+   *     operations.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   protected Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -60,22 +81,47 @@ public class Api {
     this.mkp = mkp;
   }
 
+  /**
+   * Writes a {@link BaseItem} item to the DynamoDB table.
+   *
+   * @param modeledItem the item to write.
+   * @param <T> the subtype of item to write.
+   * @return the actual item value written ({@link Map} of {@link String}:{@link AttributeValue}).
+   */
   protected <T extends BaseItem> Map<String, AttributeValue> writeItem(T modeledItem) {
     Map<String, AttributeValue> ddbItem = modeledItem.toItem();
     ddbClient.putItem(tableName, ddbItem);
     return ddbItem;
   }
 
+  /**
+   * Retrieves a {@link PointerItem} for the supplied key.
+   *
+   * @param key the key for which to fetch the {@link PointerItem}.
+   * @return the {@link PointerItem} found.
+   */
   protected PointerItem getPointerItem(String key) {
     GetItemResult result = ddbClient.getItem(tableName, PointerItem.atKey(key));
     PointerItem pointer = PointerItem.fromItem(result.getItem());
     return pointer;
   }
 
+  /**
+   * Retrieves the {@link PointerItem} for an associated {@link ContextItem}-pointer pair.
+   *
+   * @param contextItem the {@link ContextItem} with the desired document pointer key.
+   * @return the {@link PointerItem} for that context and pointer pair.
+   */
   protected PointerItem getPointerItem(ContextItem contextItem) {
     return getPointerItem(contextItem.sortKey().getS());
   }
 
+  /**
+   * Query DynamoDB for the records associated with the supplied context key.
+   *
+   * @param contextKey the key for which to retrieve the list of matching records.
+   * @return the {@link Set} of {@link PointerItem}s that have that context key.
+   */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
     QueryResult result = ddbClient.query(ContextItem.queryFor(contextKey).withTableName(tableName));
     Set<ContextItem> contextItems =
@@ -85,6 +131,12 @@ public class Api {
     return pointerItems;
   }
 
+  /**
+   * Helper to perform the write operations required to store the provided {@link DocumentBundle} in
+   * the Document Bucket system.
+   *
+   * @param bundle the document to store.
+   */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setUserMetadata(bundle.getPointer().getContext());
@@ -95,8 +147,12 @@ public class Api {
         metadata);
   }
 
-  // TODO Return some kind of bundle so that data has been pulled from the stream
-  // but metadata is returned as well?
+  /**
+   * Retrieve the bytes associated with the key in S3.
+   *
+   * @param key the S3 key to retrieve.
+   * @return the bytes for that key.
+   */
   protected byte[] getObjectData(String key) {
     S3Object object = s3Client.getObject(bucketName, key);
     byte[] result;
@@ -108,6 +164,13 @@ public class Api {
     return result;
   }
 
+  /**
+   * Lists all of the Document Bucket {@link PointerItem}s in the DynamoDB table.
+   *
+   * <p>These correspond to documents in the Document Bucket.
+   *
+   * @return the {@link Set} of {@link PointerItem}s in the Document Bucket.
+   */
   public Set<PointerItem> list() {
     ScanResult result = ddbClient.scan(tableName, PointerItem.filterFor());
     Set<PointerItem> mappedItems =
@@ -115,10 +178,24 @@ public class Api {
     return mappedItems;
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket.
+   *
+   * @param data the data to store.
+   * @return the {@link PointerItem} under which this data is stored.
+   */
   public PointerItem store(byte[] data) {
     return store(data, Collections.emptyMap());
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket, along with the supplied
+   * Context.
+   *
+   * @param data the data to store.
+   * @param context the context for this data.
+   * @return the {@link PointerItem} under which this data and context are stored.
+   */
   public PointerItem store(byte[] data, Map<String, String> context) {
     CryptoResult<byte[], KmsMasterKey> encryptedMessage = awsEncryptionSdk.encryptData(mkp, data);
     DocumentBundle bundle =
@@ -128,18 +205,46 @@ public class Api {
     return bundle.getPointer();
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key) {
     return retrieve(key, Collections.emptySet(), Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Set<String> expectedContextKeys) {
     return retrieve(key, expectedContextKeys, Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Map<String, String> expectedContext) {
     return retrieve(key, Collections.emptySet(), expectedContext);
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(
       String key, Set<String> expectedContextKeys, Map<String, String> expectedContext) {
     byte[] data = getObjectData(key);
@@ -148,6 +253,12 @@ public class Api {
     return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
   }
 
+  /**
+   * Search the Document Bucket for any documents that have context with the supplied key.
+   *
+   * @param contextKey the key for which to search for matching documents.
+   * @return the {@link Set} of {@link PointerItem}s for matching documents.
+   */
   public Set<PointerItem> searchByContextKey(String contextKey) {
     return queryForContextKey(contextKey);
   }

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/App.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
@@ -9,11 +6,22 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
+/**
+ * Entry point for writing logic to work with the Document Bucket, with a helper to obtain an API
+ * instance to use.
+ */
 public class App {
 
   // The names of resources from the configuration file must exactly match those
   // keys for the automatic mapping.
   // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+  /**
+   * Obtain a Document Bucket API initialized with the resources as configured by the bootstrap
+   * configuration system.
+   *
+   * @return a new {@link Api} configured automatically by the bootstrapping system.
+   */
   public static Api initializeDocumentBucket() {
     // Load the TOML State file with the information about launched CloudFormation resources
     State state = new State(Config.contents.base.state_file);
@@ -40,6 +48,11 @@ public class App {
   }
   // CHECKSTYLE:ON AbbreviationAsWordInName
 
+  /**
+   * Entry point for writing logic to interact with the Document Bucket system.
+   *
+   * @param args the command-line arguments to the Document Bucket.
+   */
   public static void main(String[] args) {
     // Interact with the Document Bucket here or in jshell (mvn jshell:run)
   }

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Config.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Config.java
@@ -1,11 +1,9 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
+/** Helper to pull required Document Bucket configuration keys out of the configuration system. */
 public class Config {
   private static final File DEFAULT_CONFIG = new File("../../config.toml");
   public static final ConfigContents contents =
@@ -17,8 +15,12 @@ public class Config {
   // For automatic mpaping, these classes all have names dictated by the TOML file.
   // CHECKSTYLE:OFF MemberName
   // CHECKSTYLE:OFF ParameterName
+
+  /** The top-level contents of the configuration file. */
   public static class ConfigContents {
+    /** The [base] section of the configuration file. */
     public final Base base;
+    /** The [document_bucket] section of the configuration file. */
     public final DocumentBucket document_bucket;
 
     ConfigContents(Base base, DocumentBucket document_bucket) {
@@ -27,7 +29,9 @@ public class Config {
     }
   }
 
+  /** The [base] section of the configuration file. */
   public static class Base {
+    /** The location of the state file for CloudFormation-managed AWS resource identifiers. */
     public final String state_file;
 
     Base(String state_file) {
@@ -35,8 +39,11 @@ public class Config {
     }
   }
 
+  /** The [document_bucket] section of the configuration file. */
   public static class DocumentBucket {
+    /** The [document_bucket.document_table] section of the configuration file. */
     public final DocumentTable document_table;
+    /** The [document_bucket.bucket] section of the configuration file. */
     public final Bucket bucket;
 
     DocumentBucket(DocumentTable document_table, Bucket bucket) {
@@ -45,15 +52,24 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.document_table] section of the configuration file. */
   public static class DocumentTable {
+    /** Table name. */
     public final String name;
 
+    /** Table partition key name on items. */
     public final String partition_key;
 
+    /** Item sort key name on items. */
     public final String sort_key;
 
+    /** The identifier for pointer records indicating that this record is for an S3 object. */
     public final String object_target;
 
+    /**
+     * The prefix for context records to indicate that this record is for a list of documents
+     * matching a context key.
+     */
     public final String ctx_prefix;
 
     DocumentTable(
@@ -70,9 +86,13 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.bucket] section of the configuration file. */
   public static class Bucket {
+    /** Bucket name. */
     public final String name;
+    /** The identifier of the CloudFormation output. */
     public final String output;
+    /** The identifier of the CloudFormation export. */
     public final String export;
 
     Bucket(String name, String output, String export) {

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
@@ -1,5 +1,6 @@
 package sfw.example.esdkworkshop;
 
+/** Exception to wrap errors encountered during Document Bucket operations. */
 public class DocumentBucketException extends RuntimeException {
   public DocumentBucketException(String message, Throwable cause) {
     super(message, cause);

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/State.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/State.java
@@ -3,21 +3,36 @@ package sfw.example.esdkworkshop;
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
-// For automatic mpaping, these classes all have names dictated by the TOML file.
+// For automatic mapping, these classes all have names dictated by the TOML file.
 // CHECKSTYLE:OFF MemberName
 // CHECKSTYLE:OFF ParameterName
 // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+/**
+ * Helper to pull configuration of CloudFormation-managed AWS resources out of the generated state
+ * file.
+ */
 public class State {
   public final Contents contents;
 
+  /**
+   * Parse the state file at the provided path.
+   *
+   * @param path the path to the state file.
+   */
   public State(String path) {
     contents = new Toml().read(new File(path)).to(Contents.class);
   }
 
+  /** The top-level content structure of the state file. */
   public static class Contents {
+    /** The name of the Document Bucket S3 bucket. */
     public final String DocumentBucket;
+    /** The name of the Document Bucket DynamoDB table. */
     public final String DocumentTable;
+    /** The ARN of Faythe's CMK. */
     public final String FaytheCMK;
+    /** The ARN of Walter's CMK. */
     public final String WalterCMK;
 
     Contents(String DocumentBucket, String DocumentTable, String FaytheCMK, String WalterCMK) {

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -9,6 +6,11 @@ import java.util.Map;
 import java.util.Objects;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
+ * for items corresponding to key records for indexing items with a context key. See {@link
+ * PointerItem} for items corresponding to pointer records for documents.
+ */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;
   protected final AttributeValue sortKey;
@@ -22,6 +24,12 @@ public abstract class BaseItem {
     this.sortKey = new AttributeValue(sortKey);
   }
 
+  /**
+   * Transform this modeled item into a DynamoDB item ready to write to the table.
+   *
+   * @return the item in {@link Map} of ({@link String}, {@link AttributeValue}) pairs, ready to
+   *     write.
+   */
   public Map<String, AttributeValue> toItem() {
     Map<String, AttributeValue> item = new HashMap<>();
     item.put(PARTITION_KEY_NAME, partitionKey);
@@ -29,18 +37,38 @@ public abstract class BaseItem {
     return item;
   }
 
+  /**
+   * Return the name of the item attribute used as partition key.
+   *
+   * @return the partition key item attribute name.
+   */
   public static String partitionKeyName() {
     return PARTITION_KEY_NAME;
   }
 
+  /**
+   * Return the name of the item attribute used as sort key.
+   *
+   * @return the sort key item attribute name.
+   */
   public static String sortKeyName() {
     return SORT_KEY_NAME;
   }
 
+  /**
+   * Return the value of this item's partition key attribute.
+   *
+   * @return the value of the partition key attribute.
+   */
   public AttributeValue partitionKey() {
     return this.partitionKey;
   }
 
+  /**
+   * Return the value of this item's sort key attribute.
+   *
+   * @return the value of the sort key attribute.
+   */
   public AttributeValue sortKey() {
     return this.sortKey;
   }

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -10,6 +7,10 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import java.util.Map;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket context item. Context Items are DynamoDB items
+ * that maintain lists of which Document Bucket items have which metadata keys.
+ */
 public class ContextItem extends BaseItem {
   protected static final String PREFIX = Config.contents.document_bucket.document_table.ctx_prefix;
 
@@ -17,6 +18,12 @@ public class ContextItem extends BaseItem {
     super(contextKey, objectTarget.toString());
   }
 
+  /**
+   * Ensure that the provided key is in canonical form as a {@code ContextItem} partition key.
+   *
+   * @param key the key to canonicalize (if needed).
+   * @return a canonicalized {@code key}, if it was not already in canonical form.
+   */
   protected static String canonicalize(String key) {
     if (key.startsWith(PREFIX)) {
       return key;
@@ -24,6 +31,13 @@ public class ContextItem extends BaseItem {
     return PREFIX + key;
   }
 
+  /**
+   * Helper to build a DynamoDB {@link QueryRequest} for the provided context key. This query will
+   * return pointer records that have this context key in their context.
+   *
+   * @param contextKey the context key to search for.
+   * @return the {@link QueryRequest} to find matching records in DynamoDB.
+   */
   public static QueryRequest queryFor(String contextKey) {
     Condition keyIsContextKey =
         new Condition()
@@ -34,19 +48,46 @@ public class ContextItem extends BaseItem {
     return query;
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, String objectTarget) {
     UuidKey target = new UuidKey(objectTarget);
     return new ContextItem(canonicalize(key), target);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, UuidKey objectTarget) {
     return new ContextItem(canonicalize(key), objectTarget);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, AttributeValue objectTarget) {
     return fromContext(key, objectTarget.getS());
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link ContextItem}.
+   *
+   * @param item the modeled {@link ContextItem}.
+   * @return a {@link ContextItem} for the provided item contents.
+   */
   public static ContextItem fromItem(Map<String, AttributeValue> item) {
     String contextKey = item.get(partitionKeyName()).getS();
     String objectTarget = item.get(sortKeyName()).getS();

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
@@ -1,8 +1,6 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
+/** A wrapper exception for problems with data model operations. */
 public class DataModelException extends RuntimeException {
   static final long serialVersionUID = 1L;
 

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
@@ -1,12 +1,12 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A Document Bucket document. Bundles context metadata and the data itself into a modeled object.
+ */
 public class DocumentBundle {
   private final PointerItem pointer;
   private final byte[] data;
@@ -16,22 +16,52 @@ public class DocumentBundle {
     this.data = Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data.
+   *
+   * @param data the data for this bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromData(byte[] data) {
     return fromDataAndContext(data, Collections.emptyMap());
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and pointer record.
+   *
+   * @param data the data for this bundle.
+   * @param pointer the item that tracks this record in the Document Bucket database.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndPointer(byte[] data, PointerItem pointer) {
     return new DocumentBundle(data, pointer);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and context.
+   *
+   * @param data the data for this bundle.
+   * @param context the context for this document bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndContext(byte[] data, Map<String, String> context) {
     return new DocumentBundle(data, PointerItem.generate(context));
   }
 
+  /**
+   * Get the data for this {@link DocumentBundle}.
+   *
+   * @return the associated data.
+   */
   public byte[] getData() {
     return Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Get the {@link PointerItem} for this Document Bucket bundle.
+   *
+   * @return the associated {@link PointerItem}.
+   */
   public PointerItem getPointer() {
     return pointer;
   }

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -13,6 +10,11 @@ import java.util.Map;
 import java.util.Set;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket pointer item. Pointer Items are DynamoDB items
+ * that maintain records of document items in the Document Bucket S3 bucket, and their associated
+ * metadata.
+ */
 public class PointerItem extends BaseItem {
   protected static final String TARGET =
       Config.contents.document_bucket.document_table.object_target;
@@ -32,6 +34,12 @@ public class PointerItem extends BaseItem {
     this.context = context;
   }
 
+  /**
+   * Helper to provide a DynamoDB condition filter to filter for only {@link PointerItem} records
+   * during scans.
+   *
+   * @return the filter for the scan operation.
+   */
   public static Map<String, Condition> filterFor() {
     Map<String, Condition> result = new HashMap<>(1);
     result.put(
@@ -42,14 +50,32 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Create a new pointer for a new Document Bucket document, with no associated context.
+   *
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate() {
     return generate(Collections.emptyMap());
   }
 
+  /**
+   * Create a new pointer for a Document Bucket document with the provided context.
+   *
+   * @param context the context for this document.
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate(Map<String, String> context) {
     return fromKeyAndContext(new UuidKey().toString(), context);
   }
 
+  /**
+   * Return a modeled {@link PointerItem} representing the associated pointer key and context.
+   *
+   * @param key the pointer key for this item.
+   * @param context the context for this document record.
+   * @return the {@link PointerItem} for this record.
+   */
   public static PointerItem fromKeyAndContext(String key, Map<String, String> context) {
     Map<String, AttributeValue> attributeContext = new HashMap<>(context.size());
 
@@ -60,6 +86,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(new UuidKey(key), attributeContext);
   }
 
+  /**
+   * Retrieve the context for this document item that this record points to.
+   *
+   * @return the context for this pointer's document.
+   */
   public Map<String, String> getContext() {
     Map<String, String> result = new HashMap<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {
@@ -75,11 +106,25 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(String key) {
     new UuidKey(key); // Check validity
     return atKey(new AttributeValue(key));
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(AttributeValue key) {
     Map<String, AttributeValue> result = new HashMap<>(2);
     result.put(partitionKeyName(), key);
@@ -87,6 +132,12 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link PointerItem}.
+   *
+   * @param item the modeled {@link PointerItem}.
+   * @return a {@link PointerItem} for the provided item contents.
+   */
   public static PointerItem fromItem(Map<String, AttributeValue> item) {
     UuidKey partitionKey = new UuidKey(item.remove(partitionKeyName()).getS());
     String sortKey = item.remove(sortKeyName()).getS();
@@ -97,6 +148,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(partitionKey, item);
   }
 
+  /**
+   * Retrieve the set of DynamoDB items for this pointer record's context keys.
+   *
+   * @return a {@link Set} of {@link ContextItem}s for each key in this pointer's context.
+   */
   public Set<ContextItem> contextItems() {
     HashSet<ContextItem> contextItems = new HashSet<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
@@ -1,10 +1,8 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.UUID;
 
+/** Models the unique key for identifying pointer items in S3 and DynamoDB. */
 public class UuidKey {
   private final UUID key;
 

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
@@ -1,0 +1,2 @@
+/** Objects that model the internal state and associations of the Document Bucket system. */
+package sfw.example.esdkworkshop.datamodel;

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/package-info.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The public-facing API and configuration resources for interacting with the Document Bucket
+ * system.
+ */
+package sfw.example.esdkworkshop;

--- a/exercises/java/multi-cmk-start/Makefile
+++ b/exercises/java/multi-cmk-start/Makefile
@@ -5,3 +5,7 @@ coverage:
 	cd ./target/site/jacoco/; python3 -m http.server &
 	elinks http://localhost:8000
 	killall python3
+
+javadoc:
+	mvn javadoc:javadoc
+	cd ./target/site/apidocs; python3 -m http.server

--- a/exercises/java/multi-cmk-start/checkstyle.xml
+++ b/exercises/java/multi-cmk-start/checkstyle.xml
@@ -23,7 +23,7 @@
     </module>
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Excludes all 'module-info.java' files              -->

--- a/exercises/java/multi-cmk-start/pom.xml
+++ b/exercises/java/multi-cmk-start/pom.xml
@@ -174,7 +174,7 @@
                 <executions>
                     <execution>
                         <id>validate</id>
-                        <phase>verify</phase>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
@@ -28,6 +25,7 @@ import sfw.example.esdkworkshop.datamodel.ContextItem;
 import sfw.example.esdkworkshop.datamodel.DocumentBundle;
 import sfw.example.esdkworkshop.datamodel.PointerItem;
 
+/** Defines the public interface to the Document Bucket operations. */
 public class Api {
   private final AmazonDynamoDB ddbClient;
   private final AmazonS3 s3Client;
@@ -36,6 +34,16 @@ public class Api {
   private final String tableName;
   private final String bucketName;
 
+  /**
+   * Construct a Document Bucket {@code Api} using a default {@link AwsCrypto} instance.
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   public Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -45,6 +53,19 @@ public class Api {
     this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
   }
 
+  /**
+   * Construct a Document Bucket {@code Api} using the provided {@link AwsCrypto} instance.
+   * (Included to facilitate unit testing.)
+   *
+   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
+   * @param tableName the name of the Document Bucket table.
+   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
+   * @param bucketName the name of the Document Bucket, err, bucket.
+   * @param awsEncryptionSdk the {@link AwsCrypto} instance to use for Encryption and Decryption
+   *     operations.
+   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
+   *     {@link AwsCrypto}.
+   */
   protected Api(
       AmazonDynamoDB ddbClient,
       String tableName,
@@ -60,22 +81,47 @@ public class Api {
     this.mkp = mkp;
   }
 
+  /**
+   * Writes a {@link BaseItem} item to the DynamoDB table.
+   *
+   * @param modeledItem the item to write.
+   * @param <T> the subtype of item to write.
+   * @return the actual item value written ({@link Map} of {@link String}:{@link AttributeValue}).
+   */
   protected <T extends BaseItem> Map<String, AttributeValue> writeItem(T modeledItem) {
     Map<String, AttributeValue> ddbItem = modeledItem.toItem();
     ddbClient.putItem(tableName, ddbItem);
     return ddbItem;
   }
 
+  /**
+   * Retrieves a {@link PointerItem} for the supplied key.
+   *
+   * @param key the key for which to fetch the {@link PointerItem}.
+   * @return the {@link PointerItem} found.
+   */
   protected PointerItem getPointerItem(String key) {
     GetItemResult result = ddbClient.getItem(tableName, PointerItem.atKey(key));
     PointerItem pointer = PointerItem.fromItem(result.getItem());
     return pointer;
   }
 
+  /**
+   * Retrieves the {@link PointerItem} for an associated {@link ContextItem}-pointer pair.
+   *
+   * @param contextItem the {@link ContextItem} with the desired document pointer key.
+   * @return the {@link PointerItem} for that context and pointer pair.
+   */
   protected PointerItem getPointerItem(ContextItem contextItem) {
     return getPointerItem(contextItem.sortKey().getS());
   }
 
+  /**
+   * Query DynamoDB for the records associated with the supplied context key.
+   *
+   * @param contextKey the key for which to retrieve the list of matching records.
+   * @return the {@link Set} of {@link PointerItem}s that have that context key.
+   */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
     QueryResult result = ddbClient.query(ContextItem.queryFor(contextKey).withTableName(tableName));
     Set<ContextItem> contextItems =
@@ -85,6 +131,12 @@ public class Api {
     return pointerItems;
   }
 
+  /**
+   * Helper to perform the write operations required to store the provided {@link DocumentBundle} in
+   * the Document Bucket system.
+   *
+   * @param bundle the document to store.
+   */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setUserMetadata(bundle.getPointer().getContext());
@@ -95,8 +147,12 @@ public class Api {
         metadata);
   }
 
-  // TODO Return some kind of bundle so that data has been pulled from the stream
-  // but metadata is returned as well?
+  /**
+   * Retrieve the bytes associated with the key in S3.
+   *
+   * @param key the S3 key to retrieve.
+   * @return the bytes for that key.
+   */
   protected byte[] getObjectData(String key) {
     S3Object object = s3Client.getObject(bucketName, key);
     byte[] result;
@@ -108,6 +164,13 @@ public class Api {
     return result;
   }
 
+  /**
+   * Lists all of the Document Bucket {@link PointerItem}s in the DynamoDB table.
+   *
+   * <p>These correspond to documents in the Document Bucket.
+   *
+   * @return the {@link Set} of {@link PointerItem}s in the Document Bucket.
+   */
   public Set<PointerItem> list() {
     ScanResult result = ddbClient.scan(tableName, PointerItem.filterFor());
     Set<PointerItem> mappedItems =
@@ -115,10 +178,24 @@ public class Api {
     return mappedItems;
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket.
+   *
+   * @param data the data to store.
+   * @return the {@link PointerItem} under which this data is stored.
+   */
   public PointerItem store(byte[] data) {
     return store(data, Collections.emptyMap());
   }
 
+  /**
+   * Stores the supplied Data as a new document in the Document Bucket, along with the supplied
+   * Context.
+   *
+   * @param data the data to store.
+   * @param context the context for this data.
+   * @return the {@link PointerItem} under which this data and context are stored.
+   */
   public PointerItem store(byte[] data, Map<String, String> context) {
     CryptoResult<byte[], KmsMasterKey> encryptedMessage = awsEncryptionSdk.encryptData(mkp, data);
     DocumentBundle bundle =
@@ -128,18 +205,46 @@ public class Api {
     return bundle.getPointer();
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key) {
     return retrieve(key, Collections.emptySet(), Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Set<String> expectedContextKeys) {
     return retrieve(key, expectedContextKeys, Collections.emptyMap());
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(String key, Map<String, String> expectedContext) {
     return retrieve(key, Collections.emptySet(), expectedContext);
   }
 
+  /**
+   * Retrieves a document at the provided key.
+   *
+   * @param key the key under which the document and its metadata are stored.
+   * @param expectedContextKeys TODO do something with this argument. :)
+   * @param expectedContext TODO do something with this argument. :)
+   * @return the {@link DocumentBundle} containing the document data and its metadata.
+   */
   public DocumentBundle retrieve(
       String key, Set<String> expectedContextKeys, Map<String, String> expectedContext) {
     byte[] data = getObjectData(key);
@@ -148,6 +253,12 @@ public class Api {
     return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
   }
 
+  /**
+   * Search the Document Bucket for any documents that have context with the supplied key.
+   *
+   * @param contextKey the key for which to search for matching documents.
+   * @return the {@link Set} of {@link PointerItem}s for matching documents.
+   */
   public Set<PointerItem> searchByContextKey(String contextKey) {
     return queryForContextKey(contextKey);
   }

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/App.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
@@ -9,11 +6,22 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
+/**
+ * Entry point for writing logic to work with the Document Bucket, with a helper to obtain an API
+ * instance to use.
+ */
 public class App {
 
   // The names of resources from the configuration file must exactly match those
   // keys for the automatic mapping.
   // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+  /**
+   * Obtain a Document Bucket API initialized with the resources as configured by the bootstrap
+   * configuration system.
+   *
+   * @return a new {@link Api} configured automatically by the bootstrapping system.
+   */
   public static Api initializeDocumentBucket() {
     // Load the TOML State file with the information about launched CloudFormation resources
     State state = new State(Config.contents.base.state_file);
@@ -39,6 +47,11 @@ public class App {
   }
   // CHECKSTYLE:ON AbbreviationAsWordInName
 
+  /**
+   * Entry point for writing logic to interact with the Document Bucket system.
+   *
+   * @param args the command-line arguments to the Document Bucket.
+   */
   public static void main(String[] args) {
     // Interact with the Document Bucket here or in jshell (mvn jshell:run)
   }

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Config.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Config.java
@@ -1,11 +1,9 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop;
 
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
+/** Helper to pull required Document Bucket configuration keys out of the configuration system. */
 public class Config {
   private static final File DEFAULT_CONFIG = new File("../../config.toml");
   public static final ConfigContents contents =
@@ -17,8 +15,12 @@ public class Config {
   // For automatic mpaping, these classes all have names dictated by the TOML file.
   // CHECKSTYLE:OFF MemberName
   // CHECKSTYLE:OFF ParameterName
+
+  /** The top-level contents of the configuration file. */
   public static class ConfigContents {
+    /** The [base] section of the configuration file. */
     public final Base base;
+    /** The [document_bucket] section of the configuration file. */
     public final DocumentBucket document_bucket;
 
     ConfigContents(Base base, DocumentBucket document_bucket) {
@@ -27,7 +29,9 @@ public class Config {
     }
   }
 
+  /** The [base] section of the configuration file. */
   public static class Base {
+    /** The location of the state file for CloudFormation-managed AWS resource identifiers. */
     public final String state_file;
 
     Base(String state_file) {
@@ -35,8 +39,11 @@ public class Config {
     }
   }
 
+  /** The [document_bucket] section of the configuration file. */
   public static class DocumentBucket {
+    /** The [document_bucket.document_table] section of the configuration file. */
     public final DocumentTable document_table;
+    /** The [document_bucket.bucket] section of the configuration file. */
     public final Bucket bucket;
 
     DocumentBucket(DocumentTable document_table, Bucket bucket) {
@@ -45,15 +52,24 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.document_table] section of the configuration file. */
   public static class DocumentTable {
+    /** Table name. */
     public final String name;
 
+    /** Table partition key name on items. */
     public final String partition_key;
 
+    /** Item sort key name on items. */
     public final String sort_key;
 
+    /** The identifier for pointer records indicating that this record is for an S3 object. */
     public final String object_target;
 
+    /**
+     * The prefix for context records to indicate that this record is for a list of documents
+     * matching a context key.
+     */
     public final String ctx_prefix;
 
     DocumentTable(
@@ -70,9 +86,13 @@ public class Config {
     }
   }
 
+  /** The [document_bucket.bucket] section of the configuration file. */
   public static class Bucket {
+    /** Bucket name. */
     public final String name;
+    /** The identifier of the CloudFormation output. */
     public final String output;
+    /** The identifier of the CloudFormation export. */
     public final String export;
 
     Bucket(String name, String output, String export) {

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/DocumentBucketException.java
@@ -1,5 +1,6 @@
 package sfw.example.esdkworkshop;
 
+/** Exception to wrap errors encountered during Document Bucket operations. */
 public class DocumentBucketException extends RuntimeException {
   public DocumentBucketException(String message, Throwable cause) {
     super(message, cause);

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/State.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/State.java
@@ -3,21 +3,36 @@ package sfw.example.esdkworkshop;
 import com.moandjiezana.toml.Toml;
 import java.io.File;
 
-// For automatic mpaping, these classes all have names dictated by the TOML file.
+// For automatic mapping, these classes all have names dictated by the TOML file.
 // CHECKSTYLE:OFF MemberName
 // CHECKSTYLE:OFF ParameterName
 // CHECKSTYLE:OFF AbbreviationAsWordInName
+
+/**
+ * Helper to pull configuration of CloudFormation-managed AWS resources out of the generated state
+ * file.
+ */
 public class State {
   public final Contents contents;
 
+  /**
+   * Parse the state file at the provided path.
+   *
+   * @param path the path to the state file.
+   */
   public State(String path) {
     contents = new Toml().read(new File(path)).to(Contents.class);
   }
 
+  /** The top-level content structure of the state file. */
   public static class Contents {
+    /** The name of the Document Bucket S3 bucket. */
     public final String DocumentBucket;
+    /** The name of the Document Bucket DynamoDB table. */
     public final String DocumentTable;
+    /** The ARN of Faythe's CMK. */
     public final String FaytheCMK;
+    /** The ARN of Walter's CMK. */
     public final String WalterCMK;
 
     Contents(String DocumentBucket, String DocumentTable, String FaytheCMK, String WalterCMK) {

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/BaseItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -9,6 +6,11 @@ import java.util.Map;
 import java.util.Objects;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Parent class for modeling items for the DocumentBucket DynamoDB table. See {@link ContextItem}
+ * for items corresponding to key records for indexing items with a context key. See {@link
+ * PointerItem} for items corresponding to pointer records for documents.
+ */
 public abstract class BaseItem {
   protected final AttributeValue partitionKey;
   protected final AttributeValue sortKey;
@@ -22,6 +24,12 @@ public abstract class BaseItem {
     this.sortKey = new AttributeValue(sortKey);
   }
 
+  /**
+   * Transform this modeled item into a DynamoDB item ready to write to the table.
+   *
+   * @return the item in {@link Map} of ({@link String}, {@link AttributeValue}) pairs, ready to
+   *     write.
+   */
   public Map<String, AttributeValue> toItem() {
     Map<String, AttributeValue> item = new HashMap<>();
     item.put(PARTITION_KEY_NAME, partitionKey);
@@ -29,18 +37,38 @@ public abstract class BaseItem {
     return item;
   }
 
+  /**
+   * Return the name of the item attribute used as partition key.
+   *
+   * @return the partition key item attribute name.
+   */
   public static String partitionKeyName() {
     return PARTITION_KEY_NAME;
   }
 
+  /**
+   * Return the name of the item attribute used as sort key.
+   *
+   * @return the sort key item attribute name.
+   */
   public static String sortKeyName() {
     return SORT_KEY_NAME;
   }
 
+  /**
+   * Return the value of this item's partition key attribute.
+   *
+   * @return the value of the partition key attribute.
+   */
   public AttributeValue partitionKey() {
     return this.partitionKey;
   }
 
+  /**
+   * Return the value of this item's sort key attribute.
+   *
+   * @return the value of the sort key attribute.
+   */
   public AttributeValue sortKey() {
     return this.sortKey;
   }

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/ContextItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -10,6 +7,10 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import java.util.Map;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket context item. Context Items are DynamoDB items
+ * that maintain lists of which Document Bucket items have which metadata keys.
+ */
 public class ContextItem extends BaseItem {
   protected static final String PREFIX = Config.contents.document_bucket.document_table.ctx_prefix;
 
@@ -17,6 +18,12 @@ public class ContextItem extends BaseItem {
     super(contextKey, objectTarget.toString());
   }
 
+  /**
+   * Ensure that the provided key is in canonical form as a {@code ContextItem} partition key.
+   *
+   * @param key the key to canonicalize (if needed).
+   * @return a canonicalized {@code key}, if it was not already in canonical form.
+   */
   protected static String canonicalize(String key) {
     if (key.startsWith(PREFIX)) {
       return key;
@@ -24,6 +31,13 @@ public class ContextItem extends BaseItem {
     return PREFIX + key;
   }
 
+  /**
+   * Helper to build a DynamoDB {@link QueryRequest} for the provided context key. This query will
+   * return pointer records that have this context key in their context.
+   *
+   * @param contextKey the context key to search for.
+   * @return the {@link QueryRequest} to find matching records in DynamoDB.
+   */
   public static QueryRequest queryFor(String contextKey) {
     Condition keyIsContextKey =
         new Condition()
@@ -34,19 +48,46 @@ public class ContextItem extends BaseItem {
     return query;
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, String objectTarget) {
     UuidKey target = new UuidKey(objectTarget);
     return new ContextItem(canonicalize(key), target);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, UuidKey objectTarget) {
     return new ContextItem(canonicalize(key), objectTarget);
   }
 
+  /**
+   * Return a new {@link ContextItem} from the provided key and target.
+   *
+   * @param key the context key for which to associate a new item.
+   * @param objectTarget the pointer key that has this context key.
+   * @return a new {@link ContextItem} for that context key and pointer target.
+   */
   public static ContextItem fromContext(String key, AttributeValue objectTarget) {
     return fromContext(key, objectTarget.getS());
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link ContextItem}.
+   *
+   * @param item the modeled {@link ContextItem}.
+   * @return a {@link ContextItem} for the provided item contents.
+   */
   public static ContextItem fromItem(Map<String, AttributeValue> item) {
     String contextKey = item.get(partitionKeyName()).getS();
     String objectTarget = item.get(sortKeyName()).getS();

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DataModelException.java
@@ -1,8 +1,6 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
+/** A wrapper exception for problems with data model operations. */
 public class DataModelException extends RuntimeException {
   static final long serialVersionUID = 1L;
 

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/DocumentBundle.java
@@ -1,12 +1,12 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A Document Bucket document. Bundles context metadata and the data itself into a modeled object.
+ */
 public class DocumentBundle {
   private final PointerItem pointer;
   private final byte[] data;
@@ -16,22 +16,52 @@ public class DocumentBundle {
     this.data = Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data.
+   *
+   * @param data the data for this bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromData(byte[] data) {
     return fromDataAndContext(data, Collections.emptyMap());
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and pointer record.
+   *
+   * @param data the data for this bundle.
+   * @param pointer the item that tracks this record in the Document Bucket database.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndPointer(byte[] data, PointerItem pointer) {
     return new DocumentBundle(data, pointer);
   }
 
+  /**
+   * Construct a new Document Bucket bundle from the provided data and context.
+   *
+   * @param data the data for this bundle.
+   * @param context the context for this document bundle.
+   * @return a new {@link DocumentBundle} for storage in the Document Bucket.
+   */
   public static DocumentBundle fromDataAndContext(byte[] data, Map<String, String> context) {
     return new DocumentBundle(data, PointerItem.generate(context));
   }
 
+  /**
+   * Get the data for this {@link DocumentBundle}.
+   *
+   * @return the associated data.
+   */
   public byte[] getData() {
     return Arrays.copyOf(data, data.length);
   }
 
+  /**
+   * Get the {@link PointerItem} for this Document Bucket bundle.
+   *
+   * @return the associated {@link PointerItem}.
+   */
   public PointerItem getPointer() {
     return pointer;
   }

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/PointerItem.java
@@ -1,6 +1,3 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -13,6 +10,11 @@ import java.util.Map;
 import java.util.Set;
 import sfw.example.esdkworkshop.Config;
 
+/**
+ * Modeled item corresponding to a Document Bucket pointer item. Pointer Items are DynamoDB items
+ * that maintain records of document items in the Document Bucket S3 bucket, and their associated
+ * metadata.
+ */
 public class PointerItem extends BaseItem {
   protected static final String TARGET =
       Config.contents.document_bucket.document_table.object_target;
@@ -32,6 +34,12 @@ public class PointerItem extends BaseItem {
     this.context = context;
   }
 
+  /**
+   * Helper to provide a DynamoDB condition filter to filter for only {@link PointerItem} records
+   * during scans.
+   *
+   * @return the filter for the scan operation.
+   */
   public static Map<String, Condition> filterFor() {
     Map<String, Condition> result = new HashMap<>(1);
     result.put(
@@ -42,14 +50,32 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Create a new pointer for a new Document Bucket document, with no associated context.
+   *
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate() {
     return generate(Collections.emptyMap());
   }
 
+  /**
+   * Create a new pointer for a Document Bucket document with the provided context.
+   *
+   * @param context the context for this document.
+   * @return a new {@link PointerItem} for a new document record.
+   */
   public static PointerItem generate(Map<String, String> context) {
     return fromKeyAndContext(new UuidKey().toString(), context);
   }
 
+  /**
+   * Return a modeled {@link PointerItem} representing the associated pointer key and context.
+   *
+   * @param key the pointer key for this item.
+   * @param context the context for this document record.
+   * @return the {@link PointerItem} for this record.
+   */
   public static PointerItem fromKeyAndContext(String key, Map<String, String> context) {
     Map<String, AttributeValue> attributeContext = new HashMap<>(context.size());
 
@@ -60,6 +86,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(new UuidKey(key), attributeContext);
   }
 
+  /**
+   * Retrieve the context for this document item that this record points to.
+   *
+   * @return the context for this pointer's document.
+   */
   public Map<String, String> getContext() {
     Map<String, String> result = new HashMap<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {
@@ -75,11 +106,25 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(String key) {
     new UuidKey(key); // Check validity
     return atKey(new AttributeValue(key));
   }
 
+  /**
+   * Transform the provided pointer record key into a DynamoDB key item. This provides a DynamoDB
+   * item that has the partition key and sort key populated.
+   *
+   * @param key the key to transform.
+   * @return a DynamoDB-formatted {@link PointerItem} for this key.
+   */
   public static Map<String, AttributeValue> atKey(AttributeValue key) {
     Map<String, AttributeValue> result = new HashMap<>(2);
     result.put(partitionKeyName(), key);
@@ -87,6 +132,12 @@ public class PointerItem extends BaseItem {
     return result;
   }
 
+  /**
+   * Helper function to transform a DynamoDB item into a modeled {@link PointerItem}.
+   *
+   * @param item the modeled {@link PointerItem}.
+   * @return a {@link PointerItem} for the provided item contents.
+   */
   public static PointerItem fromItem(Map<String, AttributeValue> item) {
     UuidKey partitionKey = new UuidKey(item.remove(partitionKeyName()).getS());
     String sortKey = item.remove(sortKeyName()).getS();
@@ -97,6 +148,11 @@ public class PointerItem extends BaseItem {
     return new PointerItem(partitionKey, item);
   }
 
+  /**
+   * Retrieve the set of DynamoDB items for this pointer record's context keys.
+   *
+   * @return a {@link Set} of {@link ContextItem}s for each key in this pointer's context.
+   */
   public Set<ContextItem> contextItems() {
     HashSet<ContextItem> contextItems = new HashSet<>(context.size());
     for (Map.Entry<String, AttributeValue> entry : context.entrySet()) {

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/UuidKey.java
@@ -1,10 +1,8 @@
-// CHECKSTYLE:OFF MissingJavadocMethod
-// TODO https://github.com/aws-samples/busy-engineers-document-bucket/issues/24
-
 package sfw.example.esdkworkshop.datamodel;
 
 import java.util.UUID;
 
+/** Models the unique key for identifying pointer items in S3 and DynamoDB. */
 public class UuidKey {
   private final UUID key;
 

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/datamodel/package-info.java
@@ -1,0 +1,2 @@
+/** Objects that model the internal state and associations of the Document Bucket system. */
+package sfw.example.esdkworkshop.datamodel;

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/package-info.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The public-facing API and configuration resources for interacting with the Document Bucket
+ * system.
+ */
+package sfw.example.esdkworkshop;


### PR DESCRIPTION
*Issue #, if available:* Addresses most of  #24. Still need to build-test an access mechanism from within Cloud9.

*Description of changes:* Javadoc for all `protected`-or-more access items for all workshop exercises.

Note to reviewers:

This change looks really big but has a few pivotal review points and is otherwise largely duplicated. Content between folders is largely the same. If you review the following sets of changes you've got the changeset:

* https://github.com/aws-samples/busy-engineers-document-bucket/commit/26b52282a62fdffcfec1fd40744d97271b6450ac is the primary change to review.
* https://github.com/aws-samples/busy-engineers-document-bucket/commit/041d3152242d4a6cc28dd144bdfb9677d983bb83 has edits to omit information for future exercises. Review `App.java` and `Api.java`.
* https://github.com/aws-samples/busy-engineers-document-bucket/commit/6e37f8f30e3386d1a5282f59bd4cf6ef1cabc8be has the last set of edits to omit information. Review `App.java` and `Api.java`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
