### PR TITLE
feat(python): API docs for all exercises.

### DIFF
--- a/exercises/python/add-esdk-complete/doc/conf.py
+++ b/exercises/python/add-esdk-complete/doc/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Document Bucket'
+copyright = '2019, Amazon.com, Inc. or its affiliates'
+author = 'Busy Engineer'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/exercises/python/add-esdk-complete/doc/index.rst
+++ b/exercises/python/add-esdk-complete/doc/index.rst
@@ -1,0 +1,23 @@
+.. Document Bucket documentation master file, created by
+   sphinx-quickstart on Sat Nov 30 12:10:30 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Document Bucket's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   source/*
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/exercises/python/add-esdk-complete/doc/source/document_bucket.rst
+++ b/exercises/python/add-esdk-complete/doc/source/document_bucket.rst
@@ -1,0 +1,38 @@
+document\_bucket package
+========================
+
+Submodules
+----------
+
+document\_bucket.api module
+---------------------------
+
+.. automodule:: document_bucket.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.config module
+------------------------------
+
+.. automodule:: document_bucket.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.model module
+-----------------------------
+
+.. automodule:: document_bucket.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: document_bucket
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/exercises/python/add-esdk-complete/requirements-doc.txt
+++ b/exercises/python/add-esdk-complete/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx_rtd_theme
+sphinx
+aws_encryption_sdk
+boto3
+toml

--- a/exercises/python/add-esdk-complete/src/document_bucket/__init__.py
+++ b/exercises/python/add-esdk-complete/src/document_bucket/__init__.py
@@ -3,7 +3,6 @@
 
 import os
 
-
 # ADD-ESDK-COMPLETE: Add the ESDK Dependency
 import aws_encryption_sdk  # type: ignore
 import boto3  # type: ignore

--- a/exercises/python/add-esdk-complete/src/document_bucket/__init__.py
+++ b/exercises/python/add-esdk-complete/src/document_bucket/__init__.py
@@ -14,6 +14,10 @@ from .config import config
 
 
 def initialize() -> DocumentBucketOperations:
+    """
+    Configure a Document Bucket API automatically with resources bootstrapped
+    by CloudFormation.
+    """
     # Load the pointers to CloudFormation resources that you just deployed
     state = toml.load(os.path.expanduser(config["base"]["state_file"]))["state"]
 

--- a/exercises/python/add-esdk-complete/src/document_bucket/api.py
+++ b/exercises/python/add-esdk-complete/src/document_bucket/api.py
@@ -7,7 +7,8 @@ from typing import Dict, Set
 import aws_encryption_sdk  # type: ignore
 from aws_encryption_sdk import KMSMasterKeyProvider  # type: ignore
 
-from .model import ContextItem, ContextQuery, DocumentBundle, PointerItem, PointerQuery
+from .model import (ContextItem, ContextQuery, DocumentBundle, PointerItem,
+                    PointerQuery)
 
 
 class DocumentBucketOperations:
@@ -99,6 +100,7 @@ class DocumentBucketOperations:
         :returns: the document, its key, and associated context
         """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
+        # ADD-ESDK-COMPLETE: Add Decryption to retrieve
         encrypted_data = self._get_object(item)
         plaintext, header = aws_encryption_sdk.decrypt(
             source=encrypted_data, key_provider=self.master_key_provider

--- a/exercises/python/add-esdk-complete/src/document_bucket/api.py
+++ b/exercises/python/add-esdk-complete/src/document_bucket/api.py
@@ -7,14 +7,25 @@ from typing import Dict, Set
 import aws_encryption_sdk  # type: ignore
 from aws_encryption_sdk import KMSMasterKeyProvider  # type: ignore
 
-from .model import (ContextItem, ContextQuery, DocumentBundle, PointerItem,
-                    PointerQuery)
+from .model import ContextItem, ContextQuery, DocumentBundle, PointerItem, PointerQuery
 
 
 class DocumentBucketOperations:
+    """
+    Operations available for interaction with the Document Bucket.
+    """
 
     # ADD-ESDK-COMPLETE: Add the ESDK Dependency
     def __init__(self, bucket, table, master_key_provider: KMSMasterKeyProvider):
+        """
+        Initialize a new operations object with the provided arguments.
+
+        Args:
+            bucket: S3 bucket for storing document objects
+            table: DynamoDB table for storing document pointers and context keys
+            master_key_provider: Encryption SDK Master Key Provider for encryption
+                                 and decryption operations
+        """
         self.bucket = bucket
         self.table = table
         self.master_key_provider: KMSMasterKeyProvider = master_key_provider
@@ -66,6 +77,11 @@ class DocumentBucketOperations:
         return pointers
 
     def list(self) -> Set[PointerItem]:
+        """
+        List all of the inventoried items in the Document Bucket system.
+
+        :returns: the set of pointers to Document Bucket documents
+        """
         return self._scan_table()
 
     def retrieve(
@@ -74,21 +90,34 @@ class DocumentBucketOperations:
         expected_context_keys: Set[str] = set(),
         expected_context: Dict[str, str] = {},
     ) -> DocumentBundle:
+        """
+        Retrieves a document from the Document Bucket system.
+
+        :param pointer_key: the key for the document to retrieve
+        :param expected_context_keys: the set of context keys that document should have
+        :param expected_context: the set of context key-value pairs that document
+                                 should have
+        :returns: the document, its key, and associated context
+        """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
         encrypted_data = self._get_object(item)
         # ADD-ESDK-COMPLETE: Add Decryption to retrieve
         plaintext, header = aws_encryption_sdk.decrypt(
             source=encrypted_data, key_provider=self.master_key_provider
         )
-        return DocumentBundle.from_data_and_context(
-            plaintext, item.context
-        )
+        return DocumentBundle.from_data_and_context(plaintext, item.context)
 
     def store(self, data: bytes, context: Dict[str, str] = {}) -> PointerItem:
+        """
+        Stores a document in the Document Bucket system.
+
+        :param data: the bytes of the document to store
+        :param context: the context for this document
+        :returns: the pointer reference for this document in the Document Bucket system
+        """
         # ADD-ESDK-COMPLETE: Add Encryption to store
         encrypted_data, header = aws_encryption_sdk.encrypt(
-            source=data,
-            key_provider=self.master_key_provider,
+            source=data, key_provider=self.master_key_provider,
         )
         item = PointerItem.generate(context)
         self._write_pointer(item)
@@ -97,5 +126,12 @@ class DocumentBucketOperations:
         return item
 
     def search_by_context_key(self, context_key: str) -> Set[PointerItem]:
+        """
+        Search for the documents in the Document Bucket system that have the provided
+        key in their context.
+
+        :param context_key: the context key for which to find matching documents
+        :returns: the pointers for the matching documents, if any
+        """
         key = ContextQuery(context_key)
         return self._query_for_context_key(key)

--- a/exercises/python/add-esdk-complete/src/document_bucket/api.py
+++ b/exercises/python/add-esdk-complete/src/document_bucket/api.py
@@ -94,14 +94,12 @@ class DocumentBucketOperations:
         Retrieves a document from the Document Bucket system.
 
         :param pointer_key: the key for the document to retrieve
-        :param expected_context_keys: the set of context keys that document should have
-        :param expected_context: the set of context key-value pairs that document
-                                 should have
+        :param expected_context_keys: TODO do something with this parameter :)
+        :param expected_context: TODO do something with this parameter :)
         :returns: the document, its key, and associated context
         """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
         encrypted_data = self._get_object(item)
-        # ADD-ESDK-COMPLETE: Add Decryption to retrieve
         plaintext, header = aws_encryption_sdk.decrypt(
             source=encrypted_data, key_provider=self.master_key_provider
         )
@@ -112,7 +110,7 @@ class DocumentBucketOperations:
         Stores a document in the Document Bucket system.
 
         :param data: the bytes of the document to store
-        :param context: the context for this document
+        :param context: TODO do something with this parameter :)
         :returns: the pointer reference for this document in the Document Bucket system
         """
         # ADD-ESDK-COMPLETE: Add Encryption to store

--- a/exercises/python/add-esdk-complete/src/document_bucket/config.py
+++ b/exercises/python/add-esdk-complete/src/document_bucket/config.py
@@ -6,6 +6,10 @@ import sys
 
 import toml
 
+"""
+Loads and maps configuration from the Document Bucket configuration system.
+"""
+
 _CONFIG_FILE = os.path.join(sys.prefix, "config", "config.toml")
 
 config = toml.load(_CONFIG_FILE)

--- a/exercises/python/add-esdk-complete/tox.ini
+++ b/exercises/python/add-esdk-complete/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 envlist=py38
 
+[testenv:docs]
+deps =
+    -rrequirements-doc.txt
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+           python -m http.server --directory "{toxworkdir}/docs_out"
+
 [testenv:test]
 deps =
     -rrequirements-dev.txt

--- a/exercises/python/add-esdk-start/doc/conf.py
+++ b/exercises/python/add-esdk-start/doc/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Document Bucket'
+copyright = '2019, Amazon.com, Inc. or its affiliates'
+author = 'Busy Engineer'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/exercises/python/add-esdk-start/doc/index.rst
+++ b/exercises/python/add-esdk-start/doc/index.rst
@@ -1,0 +1,23 @@
+.. Document Bucket documentation master file, created by
+   sphinx-quickstart on Sat Nov 30 12:10:30 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Document Bucket's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   source/*
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/exercises/python/add-esdk-start/doc/source/document_bucket.rst
+++ b/exercises/python/add-esdk-start/doc/source/document_bucket.rst
@@ -1,0 +1,38 @@
+document\_bucket package
+========================
+
+Submodules
+----------
+
+document\_bucket.api module
+---------------------------
+
+.. automodule:: document_bucket.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.config module
+------------------------------
+
+.. automodule:: document_bucket.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.model module
+-----------------------------
+
+.. automodule:: document_bucket.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: document_bucket
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/exercises/python/add-esdk-start/requirements-doc.txt
+++ b/exercises/python/add-esdk-start/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx_rtd_theme
+sphinx
+aws_encryption_sdk
+boto3
+toml

--- a/exercises/python/add-esdk-start/src/document_bucket/__init__.py
+++ b/exercises/python/add-esdk-start/src/document_bucket/__init__.py
@@ -12,6 +12,10 @@ from .config import config
 
 
 def initialize() -> DocumentBucketOperations:
+    """
+    Configure a Document Bucket API automatically with resources bootstrapped
+    by CloudFormation.
+    """
     # Load the pointers to CloudFormation resources that you just deployed
     state = toml.load(os.path.expanduser(config["base"]["state_file"]))["state"]
 

--- a/exercises/python/add-esdk-start/src/document_bucket/api.py
+++ b/exercises/python/add-esdk-start/src/document_bucket/api.py
@@ -3,18 +3,28 @@
 
 from typing import Dict, Set
 
-from .model import (ContextItem, ContextQuery, DocumentBundle, PointerItem,
-                    PointerQuery)
+from .model import ContextItem, ContextQuery, DocumentBundle, PointerItem, PointerQuery
 
-# ADD-ESDK-START
+# ADD-ESDK-START: Add the ESDK Dependency
 
 
 class DocumentBucketOperations:
-    # ADD-ESDK-START
+    """
+    Operations available for interaction with the Document Bucket.
+    """
+
+    # ADD-ESDK-START: Add the ESDK Dependency
     def __init__(self, bucket, table):
+        """
+        Initialize a new operations object with the provided arguments.
+
+        Args:
+            bucket: S3 bucket for storing document objects
+            table: DynamoDB table for storing document pointers and context keys
+        """
         self.bucket = bucket
         self.table = table
-        # ADD-ESDK-START
+        # ADD-ESDK-START: Add the ESDK Dependency
 
     def _write_pointer(self, item: PointerItem):
         self.table.put_item(Item=item.to_item())
@@ -63,6 +73,11 @@ class DocumentBucketOperations:
         return pointers
 
     def list(self) -> Set[PointerItem]:
+        """
+        List all of the inventoried items in the Document Bucket system.
+
+        :returns: the set of pointers to Document Bucket documents
+        """
         return self._scan_table()
 
     def retrieve(
@@ -71,20 +86,41 @@ class DocumentBucketOperations:
         expected_context_keys: Set[str] = set(),
         expected_context: Dict[str, str] = {},
     ) -> DocumentBundle:
+        """
+        Retrieves a document from the Document Bucket system.
+
+        :param pointer_key: the key for the document to retrieve
+        :param expected_context_keys: TODO do something with this parameter :)
+        :param expected_context: TODO do something with this parameter :)
+        :returns: the document, its key, and associated context
+        """
+        # ADD-ESDK-START: Add Decryption to retrieve
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
-        # ADD-ESDK-START
         data = self._get_object(item)
         return DocumentBundle.from_data_and_context(data, item.context)
 
     def store(self, data: bytes, context: Dict[str, str] = {}) -> PointerItem:
-        # ADD-ESDK-START
+        """
+        Stores a document in the Document Bucket system.
+
+        :param data: the bytes of the document to store
+        :param context: TODO do something with this parameter :)
+        :returns: the pointer reference for this document in the Document Bucket system
+        """
+        # ADD-ESDK-START: Add Encryption to store
         item = PointerItem.generate(context)
         self._write_pointer(item)
-        # ADD-ESDK-START
         self._write_object(data, item)
         self._populate_key_records(item)
         return item
 
     def search_by_context_key(self, context_key: str) -> Set[PointerItem]:
+        """
+        Search for the documents in the Document Bucket system that have the provided
+        key in their context.
+
+        :param context_key: the context key for which to find matching documents
+        :returns: the pointers for the matching documents, if any
+        """
         key = ContextQuery(context_key)
         return self._query_for_context_key(key)

--- a/exercises/python/add-esdk-start/src/document_bucket/config.py
+++ b/exercises/python/add-esdk-start/src/document_bucket/config.py
@@ -6,6 +6,10 @@ import sys
 
 import toml
 
+"""
+Loads and maps configuration from the Document Bucket configuration system.
+"""
+
 _CONFIG_FILE = os.path.join(sys.prefix, "config", "config.toml")
 
 config = toml.load(_CONFIG_FILE)

--- a/exercises/python/add-esdk-start/src/document_bucket/model.py
+++ b/exercises/python/add-esdk-start/src/document_bucket/model.py
@@ -15,11 +15,21 @@ from .config import config
 
 
 class DataModelException(Exception):
+    """
+    Wrapper exception for errors with data model operations.
+    """
+
     pass
 
 
 @dataclass
 class UUIDKey:
+    """
+    Models a unique identifier for document identification in the Document Bucket.
+    Used for the storage of the document and for the identification of document records
+    in the table.
+    """
+
     key: Union[UUID, str]
 
     def __post_init__(self):
@@ -33,7 +43,13 @@ class UUIDKey:
 
 @dataclass
 class BaseItem:
+    """
+    Models a DynamoDB record in the Document Bucket system.
+    """
+
+    #: This item's value for the partition key attribute.
     partition_key: Union[UUIDKey, str]
+    #: This item's value for the sort key attribute.
     sort_key: Optional[Union[str, UUIDKey]]
 
     def __hash__(self):
@@ -48,10 +64,16 @@ class BaseItem:
 
     @classmethod
     def partition_key_name(cls) -> str:
+        """
+        :returns: the name of the item attribute used as the partition key.
+        """
         return config["document_bucket"]["document_table"]["partition_key"]
 
     @classmethod
     def sort_key_name(cls) -> str:
+        """
+        :returns: the name of the item attribute used as the sort key.
+        """
         return config["document_bucket"]["document_table"]["sort_key"]
 
     def _assert_set(self):
@@ -61,6 +83,11 @@ class BaseItem:
             raise DataModelException("sort_key not set correctly after init!")
 
     def to_item(self):
+        """
+        Convert this item to a record format ready to write to DynamoDB.
+
+        :returns: a dict ready to write to DynamoDB
+        """
         key = {
             BaseItem.partition_key_name(): self.partition_key,
             BaseItem.sort_key_name(): self.sort_key,
@@ -70,28 +97,56 @@ class BaseItem:
 
 @dataclass
 class ContextQuery:
+    """
+    Models queries for context keys.
+    """
+
     partition_key: str
 
     def __post_init__(self):
         self.partition_key = ContextItem.canonicalize(self.partition_key)
 
     def expression(self) -> Dict[str, str]:
+        """
+        Generate a query expression for this context query.
+
+        :returns: DynamoDB key expression ready for querying
+        """
         return Key(BaseItem.partition_key_name()).eq(self.partition_key)
 
 
 @dataclass
 class PointerQuery:
+    """
+    Models queries for pointer keys.
+    """
+
     partition_key: UUIDKey
 
     @staticmethod
     def from_key(pointer_key: str) -> PointerQuery:
+        """
+        :param pointer_key: the pointer key to query for
+        :returns: a PointerQuery for the provided key
+        """
         return PointerQuery(UUIDKey(pointer_key))
 
     @staticmethod
     def from_context_item(context_item) -> PointerQuery:
+        """
+        :param context_item: the context item to use to look up the associated document
+                             pointer
+        :returns: a PointerQuery ready to pass to DynamoDB to look up the associated
+                  pointer item
+        """
         return PointerQuery(context_item.sort_key)
 
     def expression(self) -> Dict[str, str]:
+        """
+        Generate a query expression for this PointerQuery.
+
+        :returns: DynamoDB key expression ready for querying
+        """
         return Key(BaseItem.partition_key_name()).eq(self.partition_key)
 
 
@@ -109,6 +164,13 @@ class ContextItem(BaseItem):
 
     @classmethod
     def canonicalize(cls, context_key: str) -> str:
+        """
+        Ensure that the provided key is in canonical form as a ContextItem partition
+        key.
+
+        :param context_key: the key to canonicalize
+        :returns: the context_key updated to canonical form, if required
+        """
         if not context_key.startswith(ContextItem._prefix()):
             context_key = ContextItem._prefix() + context_key
         return context_key
@@ -120,6 +182,12 @@ class ContextItem(BaseItem):
 
     @classmethod
     def from_item(cls, item: Dict[str, str]) -> ContextItem:
+        """
+        Map a raw DynamoDB item into a ContextItem.
+
+        :param item: the item to map
+        :returns: the modeled ContextItem
+        """
         partition_key = item.pop(BaseItem.partition_key_name())
         sort_key = item.pop(BaseItem.sort_key_name())
         return cls(partition_key, sort_key)
@@ -127,7 +195,9 @@ class ContextItem(BaseItem):
 
 @dataclass
 class PointerItem(BaseItem):
+    #: PointerItems have a fixed sort key
     sort_key: str = config["document_bucket"]["document_table"]["object_target"]
+    #: The context for the document that this PointerItem refers to
     context: Dict[str, str] = field(default_factory=dict)
 
     def __hash__(self):
@@ -147,12 +217,25 @@ class PointerItem(BaseItem):
 
     @classmethod
     def generate(cls, context: Dict[str, str]):
+        """
+        Generate a new PointerItem for a new document, and its context.
+
+        :param context: the context for the new document
+        :returns: a new PointerItem for the new document
+        """
         return PointerItem(partition_key=cls._generate_key(), context=context)
 
     @classmethod
     def from_key_and_context(
         cls, key: Union[UUIDKey, UUID, str], context: Dict[str, str]
     ) -> PointerItem:
+        """
+        Map the provided key and context into a modeled PointerItem.
+
+        :param key: the key for the document that this PointerItem references
+        :param context: the context for this document
+        :returns: a modeled PointerItem
+        """
         if not isinstance(key, UUIDKey):
             key = UUIDKey(key)
         return cls(partition_key=key, context=context)
@@ -178,6 +261,11 @@ class PointerItem(BaseItem):
         self.partition_key = str(self.partition_key)
 
     def context_items(self) -> Set[ContextItem]:
+        """
+        Get the set of ContextItems for this PointerItem record.
+
+        :returns: a ContextItem for each key of context for this PointerItem
+        """
         result: Set[ContextItem] = set()
         for context_key in self.context.keys():
             result.add(ContextItem(context_key, self.partition_key))
@@ -185,6 +273,11 @@ class PointerItem(BaseItem):
 
     @classmethod
     def filter_for(cls):
+        """
+        Helper to provide a DynamoDB filter to select PointerItem records
+
+        :returns: a key expression filter ready to use with DynamoDB operations
+        """
         return Key(BaseItem.sort_key_name()).eq(cls.sort_key)
 
     def to_item(self):
@@ -194,6 +287,12 @@ class PointerItem(BaseItem):
 
     @staticmethod
     def from_item(item: Dict[str, str]) -> PointerItem:
+        """
+        Map a raw DynamoDB item into a PointerItem.
+
+        :param item: the item to map
+        :returns: the modeled PointerItem
+        """
         partition_key = item.pop(BaseItem.partition_key_name())
         sort_key = item.pop(BaseItem.sort_key_name())
         return PointerItem(partition_key, sort_key, item)
@@ -201,10 +300,29 @@ class PointerItem(BaseItem):
 
 @dataclass
 class DocumentBundle:
+    """
+    The complete, aggregated form of a Document Bucket document. Contains the data,
+    the unique identifier key, and the context.
+    """
+
     key: BaseItem
     data: bytes
 
     @staticmethod
+    def from_pointer_and_data(key: PointerItem, data: bytes):
+        """
+        Build a bundled document from the provdied document key and data.
+
+        :returns: a DocumentBundle for this pointer and data
+        """
+        return DocumentBundle(key, data)
+
+    @staticmethod
     def from_data_and_context(data: bytes, context: Dict[str, str]):
+        """
+        Build a bundled document from the provided data and document context.
+
+        :returns: a DocumentBundle for this data and context
+        """
         key = PointerItem.generate(context)
         return DocumentBundle(key, data)

--- a/exercises/python/add-esdk-start/tox.ini
+++ b/exercises/python/add-esdk-start/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 envlist=py38
 
+[testenv:docs]
+deps =
+    -rrequirements-doc.txt
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+           python -m http.server --directory "{toxworkdir}/docs_out"
+
 [testenv:test]
 deps =
     -rrequirements-dev.txt

--- a/exercises/python/encryption-context-complete/doc/conf.py
+++ b/exercises/python/encryption-context-complete/doc/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Document Bucket'
+copyright = '2019, Amazon.com, Inc. or its affiliates'
+author = 'Busy Engineer'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/exercises/python/encryption-context-complete/doc/index.rst
+++ b/exercises/python/encryption-context-complete/doc/index.rst
@@ -1,0 +1,23 @@
+.. Document Bucket documentation master file, created by
+   sphinx-quickstart on Sat Nov 30 12:10:30 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Document Bucket's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   source/*
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/exercises/python/encryption-context-complete/doc/source/document_bucket.rst
+++ b/exercises/python/encryption-context-complete/doc/source/document_bucket.rst
@@ -1,0 +1,38 @@
+document\_bucket package
+========================
+
+Submodules
+----------
+
+document\_bucket.api module
+---------------------------
+
+.. automodule:: document_bucket.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.config module
+------------------------------
+
+.. automodule:: document_bucket.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.model module
+-----------------------------
+
+.. automodule:: document_bucket.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: document_bucket
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/exercises/python/encryption-context-complete/requirements-doc.txt
+++ b/exercises/python/encryption-context-complete/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx_rtd_theme
+sphinx
+aws_encryption_sdk
+boto3
+toml

--- a/exercises/python/encryption-context-complete/src/document_bucket/__init__.py
+++ b/exercises/python/encryption-context-complete/src/document_bucket/__init__.py
@@ -12,6 +12,10 @@ from .config import config
 
 
 def initialize() -> DocumentBucketOperations:
+    """
+    Configure a Document Bucket API automatically with resources bootstrapped
+    by CloudFormation.
+    """
     # Load the pointers to CloudFormation resources that you just deployed
     state = toml.load(os.path.expanduser(config["base"]["state_file"]))["state"]
 

--- a/exercises/python/encryption-context-complete/src/document_bucket/api.py
+++ b/exercises/python/encryption-context-complete/src/document_bucket/api.py
@@ -6,12 +6,24 @@ from typing import Dict, Set
 import aws_encryption_sdk  # type: ignore
 from aws_encryption_sdk import KMSMasterKeyProvider  # type: ignore
 
-from .model import (ContextItem, ContextQuery, DocumentBundle, PointerItem,
-                    PointerQuery)
+from .model import ContextItem, ContextQuery, DocumentBundle, PointerItem, PointerQuery
 
 
 class DocumentBucketOperations:
+    """
+    Operations available for interaction with the Document Bucket.
+    """
+
     def __init__(self, bucket, table, master_key_provider: KMSMasterKeyProvider):
+        """
+        Initialize a new operations object with the provided arguments.
+
+        Args:
+            bucket: S3 bucket for storing document objects
+            table: DynamoDB table for storing document pointers and context keys
+            master_key_provider: Encryption SDK Master Key Provider for encryption
+                                 and decryption operations
+        """
         self.bucket = bucket
         self.table = table
         self.master_key_provider: KMSMasterKeyProvider = master_key_provider
@@ -63,6 +75,11 @@ class DocumentBucketOperations:
         return pointers
 
     def list(self) -> Set[PointerItem]:
+        """
+        List all of the inventoried items in the Document Bucket system.
+
+        :returns: the set of pointers to Document Bucket documents
+        """
         return self._scan_table()
 
     def retrieve(
@@ -71,6 +88,15 @@ class DocumentBucketOperations:
         expected_context_keys: Set[str] = set(),
         expected_context: Dict[str, str] = {},
     ) -> DocumentBundle:
+        """
+        Retrieves a document from the Document Bucket system.
+
+        :param pointer_key: the key for the document to retrieve
+        :param expected_context_keys: the set of context keys that document should have
+        :param expected_context: the set of context key-value pairs that document
+                                 should have
+        :returns: the document, its key, and associated context
+        """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
         encrypted_data = self._get_object(item)
         plaintext, header = aws_encryption_sdk.decrypt(
@@ -98,6 +124,13 @@ class DocumentBucketOperations:
         return DocumentBundle.from_pointer_and_data(validatedItem, plaintext)
 
     def store(self, data: bytes, context: Dict[str, str] = {}) -> PointerItem:
+        """
+        Stores a document in the Document Bucket system.
+
+        :param data: the bytes of the document to store
+        :param context: the context for this document
+        :returns: the pointer reference for this document in the Document Bucket system
+        """
         # ENCRYPTION-CONTEXT-COMPLETE: Set Encryption Context on Encrypt
         encrypted_data, header = aws_encryption_sdk.encrypt(
             source=data,
@@ -111,5 +144,12 @@ class DocumentBucketOperations:
         return item
 
     def search_by_context_key(self, context_key: str) -> Set[PointerItem]:
+        """
+        Search for the documents in the Document Bucket system that have the provided
+        key in their context.
+
+        :param context_key: the context key for which to find matching documents
+        :returns: the pointers for the matching documents, if any
+        """
         key = ContextQuery(context_key)
         return self._query_for_context_key(key)

--- a/exercises/python/encryption-context-complete/src/document_bucket/config.py
+++ b/exercises/python/encryption-context-complete/src/document_bucket/config.py
@@ -6,6 +6,10 @@ import sys
 
 import toml
 
+"""
+Loads and maps configuration from the Document Bucket configuration system.
+"""
+
 _CONFIG_FILE = os.path.join(sys.prefix, "config", "config.toml")
 
 config = toml.load(_CONFIG_FILE)

--- a/exercises/python/encryption-context-complete/tox.ini
+++ b/exercises/python/encryption-context-complete/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 envlist=py38
 
+[testenv:docs]
+deps =
+    -rrequirements-doc.txt
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+           python -m http.server --directory "{toxworkdir}/docs_out"
+
 [testenv:test]
 deps =
     -rrequirements-dev.txt

--- a/exercises/python/encryption-context-start/doc/conf.py
+++ b/exercises/python/encryption-context-start/doc/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Document Bucket'
+copyright = '2019, Amazon.com, Inc. or its affiliates'
+author = 'Busy Engineer'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/exercises/python/encryption-context-start/doc/index.rst
+++ b/exercises/python/encryption-context-start/doc/index.rst
@@ -1,0 +1,23 @@
+.. Document Bucket documentation master file, created by
+   sphinx-quickstart on Sat Nov 30 12:10:30 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Document Bucket's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   source/*
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/exercises/python/encryption-context-start/doc/source/document_bucket.rst
+++ b/exercises/python/encryption-context-start/doc/source/document_bucket.rst
@@ -1,0 +1,38 @@
+document\_bucket package
+========================
+
+Submodules
+----------
+
+document\_bucket.api module
+---------------------------
+
+.. automodule:: document_bucket.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.config module
+------------------------------
+
+.. automodule:: document_bucket.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.model module
+-----------------------------
+
+.. automodule:: document_bucket.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: document_bucket
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/exercises/python/encryption-context-start/requirements-doc.txt
+++ b/exercises/python/encryption-context-start/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx_rtd_theme
+sphinx
+aws_encryption_sdk
+boto3
+toml

--- a/exercises/python/encryption-context-start/src/document_bucket/__init__.py
+++ b/exercises/python/encryption-context-start/src/document_bucket/__init__.py
@@ -12,6 +12,10 @@ from .config import config
 
 
 def initialize() -> DocumentBucketOperations:
+    """
+    Configure a Document Bucket API automatically with resources bootstrapped
+    by CloudFormation.
+    """
     # Load the pointers to CloudFormation resources that you just deployed
     state = toml.load(os.path.expanduser(config["base"]["state_file"]))["state"]
 

--- a/exercises/python/encryption-context-start/src/document_bucket/api.py
+++ b/exercises/python/encryption-context-start/src/document_bucket/api.py
@@ -6,12 +6,24 @@ from typing import Dict, Set
 import aws_encryption_sdk  # type: ignore
 from aws_encryption_sdk import KMSMasterKeyProvider  # type: ignore
 
-from .model import (ContextItem, ContextQuery, DocumentBundle, PointerItem,
-                    PointerQuery)
+from .model import ContextItem, ContextQuery, DocumentBundle, PointerItem, PointerQuery
 
 
 class DocumentBucketOperations:
+    """
+    Operations available for interaction with the Document Bucket.
+    """
+
     def __init__(self, bucket, table, master_key_provider: KMSMasterKeyProvider):
+        """
+        Initialize a new operations object with the provided arguments.
+
+        Args:
+            bucket: S3 bucket for storing document objects
+            table: DynamoDB table for storing document pointers and context keys
+            master_key_provider: Encryption SDK Master Key Provider for encryption
+                                 and decryption operations
+        """
         self.bucket = bucket
         self.table = table
         self.master_key_provider: KMSMasterKeyProvider = master_key_provider
@@ -63,6 +75,11 @@ class DocumentBucketOperations:
         return pointers
 
     def list(self) -> Set[PointerItem]:
+        """
+        List all of the inventoried items in the Document Bucket system.
+
+        :returns: the set of pointers to Document Bucket documents
+        """
         return self._scan_table()
 
     def retrieve(
@@ -71,6 +88,16 @@ class DocumentBucketOperations:
         expected_context_keys: Set[str] = set(),
         expected_context: Dict[str, str] = {},
     ) -> DocumentBundle:
+        """
+        Retrieves a document from the Document Bucket system.
+
+        :param pointer_key: the key for the document to retrieve
+        :param expected_context_keys: the set of context keys that document should have
+        :param expected_context: the set of context key-value pairs that document
+                                 should have
+        :returns: the document, its key, and associated context
+        """
+
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
         encrypted_data = self._get_object(item)
         plaintext, header = aws_encryption_sdk.decrypt(
@@ -83,6 +110,14 @@ class DocumentBucketOperations:
         )
 
     def store(self, data: bytes, context: Dict[str, str] = {}) -> PointerItem:
+                """
+                Stores a document in the Document Bucket system.
+
+                :param data: the bytes of the document to store
+                :param context: the context for this document
+                :returns: the pointer reference for this document in the Document
+                          Bucket system
+                """
         # ENCRYPTION-CONTEXT-START: Set Encryption Context on Encrypt
         encrypted_data, header = aws_encryption_sdk.encrypt(
             source=data,
@@ -95,5 +130,12 @@ class DocumentBucketOperations:
         return item
 
     def search_by_context_key(self, context_key: str) -> Set[PointerItem]:
+        """
+        Search for the documents in the Document Bucket system that have the provided
+        key in their context.
+
+        :param context_key: the context key for which to find matching documents
+        :returns: the pointers for the matching documents, if any
+        """
         key = ContextQuery(context_key)
         return self._query_for_context_key(key)

--- a/exercises/python/encryption-context-start/src/document_bucket/config.py
+++ b/exercises/python/encryption-context-start/src/document_bucket/config.py
@@ -6,6 +6,10 @@ import sys
 
 import toml
 
+"""
+Loads and maps configuration from the Document Bucket configuration system.
+"""
+
 _CONFIG_FILE = os.path.join(sys.prefix, "config", "config.toml")
 
 config = toml.load(_CONFIG_FILE)

--- a/exercises/python/encryption-context-start/tox.ini
+++ b/exercises/python/encryption-context-start/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 envlist=py38
 
+[testenv:docs]
+deps =
+    -rrequirements-doc.txt
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+           python -m http.server --directory "{toxworkdir}/docs_out"
+
 [testenv:test]
 deps =
     -rrequirements-dev.txt

--- a/exercises/python/multi-cmk-complete/doc/conf.py
+++ b/exercises/python/multi-cmk-complete/doc/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Document Bucket'
+copyright = '2019, Amazon.com, Inc. or its affiliates'
+author = 'Busy Engineer'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/exercises/python/multi-cmk-complete/doc/index.rst
+++ b/exercises/python/multi-cmk-complete/doc/index.rst
@@ -1,0 +1,23 @@
+.. Document Bucket documentation master file, created by
+   sphinx-quickstart on Sat Nov 30 12:10:30 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Document Bucket's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   source/*
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/exercises/python/multi-cmk-complete/doc/source/document_bucket.rst
+++ b/exercises/python/multi-cmk-complete/doc/source/document_bucket.rst
@@ -1,0 +1,38 @@
+document\_bucket package
+========================
+
+Submodules
+----------
+
+document\_bucket.api module
+---------------------------
+
+.. automodule:: document_bucket.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.config module
+------------------------------
+
+.. automodule:: document_bucket.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.model module
+-----------------------------
+
+.. automodule:: document_bucket.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: document_bucket
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/exercises/python/multi-cmk-complete/requirements-doc.txt
+++ b/exercises/python/multi-cmk-complete/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx_rtd_theme
+sphinx
+aws_encryption_sdk
+boto3
+toml

--- a/exercises/python/multi-cmk-complete/src/document_bucket/__init__.py
+++ b/exercises/python/multi-cmk-complete/src/document_bucket/__init__.py
@@ -12,6 +12,10 @@ from .config import config
 
 
 def initialize() -> DocumentBucketOperations:
+    """
+    Configure a Document Bucket API automatically with resources bootstrapped
+    by CloudFormation.
+    """
     # Load the pointers to CloudFormation resources that you just deployed
     state = toml.load(os.path.expanduser(config["base"]["state_file"]))["state"]
 

--- a/exercises/python/multi-cmk-complete/src/document_bucket/api.py
+++ b/exercises/python/multi-cmk-complete/src/document_bucket/api.py
@@ -6,12 +6,24 @@ from typing import Dict, Set
 import aws_encryption_sdk  # type: ignore
 from aws_encryption_sdk import KMSMasterKeyProvider  # type: ignore
 
-from .model import (ContextItem, ContextQuery, DocumentBundle, PointerItem,
-                    PointerQuery)
+from .model import ContextItem, ContextQuery, DocumentBundle, PointerItem, PointerQuery
 
 
 class DocumentBucketOperations:
+    """
+    Operations available for interaction with the Document Bucket.
+    """
+
     def __init__(self, bucket, table, master_key_provider: KMSMasterKeyProvider):
+        """
+        Initialize a new operations object with the provided arguments.
+
+        Args:
+            bucket: S3 bucket for storing document objects
+            table: DynamoDB table for storing document pointers and context keys
+            master_key_provider: Encryption SDK Master Key Provider for encryption
+                                 and decryption operations
+        """
         self.bucket = bucket
         self.table = table
         self.master_key_provider: KMSMasterKeyProvider = master_key_provider
@@ -63,6 +75,11 @@ class DocumentBucketOperations:
         return pointers
 
     def list(self) -> Set[PointerItem]:
+        """
+        List all of the inventoried items in the Document Bucket system.
+
+        :returns: the set of pointers to Document Bucket documents
+        """
         return self._scan_table()
 
     def retrieve(
@@ -71,19 +88,32 @@ class DocumentBucketOperations:
         expected_context_keys: Set[str] = set(),
         expected_context: Dict[str, str] = {},
     ) -> DocumentBundle:
+        """
+        Retrieves a document from the Document Bucket system.
+
+        :param pointer_key: the key for the document to retrieve
+        :param expected_context_keys: the set of context keys that document should have
+        :param expected_context: the set of context key-value pairs that document
+                                 should have
+        :returns: the document, its key, and associated context
+        """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
         encrypted_data = self._get_object(item)
         plaintext, header = aws_encryption_sdk.decrypt(
             source=encrypted_data, key_provider=self.master_key_provider
         )
-        return DocumentBundle.from_data_and_context(
-            plaintext, item.context
-        )
+        return DocumentBundle.from_data_and_context(plaintext, item.context)
 
     def store(self, data: bytes, context: Dict[str, str] = {}) -> PointerItem:
+        """
+        Stores a document in the Document Bucket system.
+
+        :param data: the bytes of the document to store
+        :param context: the context for this document
+        :returns: the pointer reference for this document in the Document Bucket system
+        """
         encrypted_data, header = aws_encryption_sdk.encrypt(
-            source=data,
-            key_provider=self.master_key_provider,
+            source=data, key_provider=self.master_key_provider,
         )
         item = PointerItem.generate(context)
         self._write_pointer(item)
@@ -92,5 +122,12 @@ class DocumentBucketOperations:
         return item
 
     def search_by_context_key(self, context_key: str) -> Set[PointerItem]:
+        """
+        Search for the documents in the Document Bucket system that have the provided
+        key in their context.
+
+        :param context_key: the context key for which to find matching documents
+        :returns: the pointers for the matching documents, if any
+        """
         key = ContextQuery(context_key)
         return self._query_for_context_key(key)

--- a/exercises/python/multi-cmk-complete/src/document_bucket/api.py
+++ b/exercises/python/multi-cmk-complete/src/document_bucket/api.py
@@ -92,9 +92,8 @@ class DocumentBucketOperations:
         Retrieves a document from the Document Bucket system.
 
         :param pointer_key: the key for the document to retrieve
-        :param expected_context_keys: the set of context keys that document should have
-        :param expected_context: the set of context key-value pairs that document
-                                 should have
+        :param expected_context_keys: TODO do something with this parameter :)
+        :param expected_context: TODO do something with this parameter :)
         :returns: the document, its key, and associated context
         """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
@@ -109,7 +108,7 @@ class DocumentBucketOperations:
         Stores a document in the Document Bucket system.
 
         :param data: the bytes of the document to store
-        :param context: the context for this document
+        :param context: TODO do something with this parameter :)
         :returns: the pointer reference for this document in the Document Bucket system
         """
         encrypted_data, header = aws_encryption_sdk.encrypt(

--- a/exercises/python/multi-cmk-complete/src/document_bucket/config.py
+++ b/exercises/python/multi-cmk-complete/src/document_bucket/config.py
@@ -6,6 +6,10 @@ import sys
 
 import toml
 
+"""
+Loads and maps configuration from the Document Bucket configuration system.
+"""
+
 _CONFIG_FILE = os.path.join(sys.prefix, "config", "config.toml")
 
 config = toml.load(_CONFIG_FILE)

--- a/exercises/python/multi-cmk-complete/tox.ini
+++ b/exercises/python/multi-cmk-complete/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 envlist=py38
 
+[testenv:docs]
+deps =
+    -rrequirements-doc.txt
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+           python -m http.server --directory "{toxworkdir}/docs_out"
+
 [testenv:test]
 deps =
     -rrequirements-dev.txt

--- a/exercises/python/multi-cmk-start/doc/conf.py
+++ b/exercises/python/multi-cmk-start/doc/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Document Bucket'
+copyright = '2019, Amazon.com, Inc. or its affiliates'
+author = 'Busy Engineer'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [ 'sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/exercises/python/multi-cmk-start/doc/index.rst
+++ b/exercises/python/multi-cmk-start/doc/index.rst
@@ -1,0 +1,23 @@
+.. Document Bucket documentation master file, created by
+   sphinx-quickstart on Sat Nov 30 12:10:30 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Document Bucket's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   source/*
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/exercises/python/multi-cmk-start/doc/source/document_bucket.rst
+++ b/exercises/python/multi-cmk-start/doc/source/document_bucket.rst
@@ -1,0 +1,38 @@
+document\_bucket package
+========================
+
+Submodules
+----------
+
+document\_bucket.api module
+---------------------------
+
+.. automodule:: document_bucket.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.config module
+------------------------------
+
+.. automodule:: document_bucket.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+document\_bucket.model module
+-----------------------------
+
+.. automodule:: document_bucket.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: document_bucket
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/exercises/python/multi-cmk-start/requirements-doc.txt
+++ b/exercises/python/multi-cmk-start/requirements-doc.txt
@@ -1,0 +1,5 @@
+sphinx_rtd_theme
+sphinx
+aws_encryption_sdk
+boto3
+toml

--- a/exercises/python/multi-cmk-start/src/document_bucket/__init__.py
+++ b/exercises/python/multi-cmk-start/src/document_bucket/__init__.py
@@ -12,6 +12,10 @@ from .config import config
 
 
 def initialize() -> DocumentBucketOperations:
+    """
+    Configure a Document Bucket API automatically with resources bootstrapped
+    by CloudFormation.
+    """
     # Load the pointers to CloudFormation resources that you just deployed
     state = toml.load(os.path.expanduser(config["base"]["state_file"]))["state"]
 

--- a/exercises/python/multi-cmk-start/src/document_bucket/api.py
+++ b/exercises/python/multi-cmk-start/src/document_bucket/api.py
@@ -6,12 +6,24 @@ from typing import Dict, Set
 import aws_encryption_sdk  # type: ignore
 from aws_encryption_sdk import KMSMasterKeyProvider  # type: ignore
 
-from .model import (ContextItem, ContextQuery, DocumentBundle, PointerItem,
-                    PointerQuery)
+from .model import ContextItem, ContextQuery, DocumentBundle, PointerItem, PointerQuery
 
 
 class DocumentBucketOperations:
+    """
+    Operations available for interaction with the Document Bucket.
+    """
+
     def __init__(self, bucket, table, master_key_provider: KMSMasterKeyProvider):
+        """
+        Initialize a new operations object with the provided arguments.
+
+        Args:
+            bucket: S3 bucket for storing document objects
+            table: DynamoDB table for storing document pointers and context keys
+            master_key_provider: Encryption SDK Master Key Provider for encryption
+                                 and decryption operations
+        """
         self.bucket = bucket
         self.table = table
         self.master_key_provider: KMSMasterKeyProvider = master_key_provider
@@ -63,6 +75,11 @@ class DocumentBucketOperations:
         return pointers
 
     def list(self) -> Set[PointerItem]:
+        """
+        List all of the inventoried items in the Document Bucket system.
+
+        :returns: the set of pointers to Document Bucket documents
+        """
         return self._scan_table()
 
     def retrieve(
@@ -71,19 +88,32 @@ class DocumentBucketOperations:
         expected_context_keys: Set[str] = set(),
         expected_context: Dict[str, str] = {},
     ) -> DocumentBundle:
+        """
+        Retrieves a document from the Document Bucket system.
+
+        :param pointer_key: the key for the document to retrieve
+        :param expected_context_keys: the set of context keys that document should have
+        :param expected_context: the set of context key-value pairs that document
+                                 should have
+        :returns: the document, its key, and associated context
+        """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
         encrypted_data = self._get_object(item)
         plaintext, header = aws_encryption_sdk.decrypt(
             source=encrypted_data, key_provider=self.master_key_provider
         )
-        return DocumentBundle.from_data_and_context(
-            plaintext, item.context
-        )
+        return DocumentBundle.from_data_and_context(plaintext, item.context)
 
     def store(self, data: bytes, context: Dict[str, str] = {}) -> PointerItem:
+        """
+        Stores a document in the Document Bucket system.
+
+        :param data: the bytes of the document to store
+        :param context: the context for this document
+        :returns: the pointer reference for this document in the Document Bucket system
+        """
         encrypted_data, header = aws_encryption_sdk.encrypt(
-            source=data,
-            key_provider=self.master_key_provider,
+            source=data, key_provider=self.master_key_provider,
         )
         item = PointerItem.generate(context)
         self._write_pointer(item)
@@ -92,5 +122,12 @@ class DocumentBucketOperations:
         return item
 
     def search_by_context_key(self, context_key: str) -> Set[PointerItem]:
+        """
+        Search for the documents in the Document Bucket system that have the provided
+        key in their context.
+
+        :param context_key: the context key for which to find matching documents
+        :returns: the pointers for the matching documents, if any
+        """
         key = ContextQuery(context_key)
         return self._query_for_context_key(key)

--- a/exercises/python/multi-cmk-start/src/document_bucket/api.py
+++ b/exercises/python/multi-cmk-start/src/document_bucket/api.py
@@ -92,9 +92,8 @@ class DocumentBucketOperations:
         Retrieves a document from the Document Bucket system.
 
         :param pointer_key: the key for the document to retrieve
-        :param expected_context_keys: the set of context keys that document should have
-        :param expected_context: the set of context key-value pairs that document
-                                 should have
+        :param expected_context_keys: TODO do something with this parameter :)
+        :param expected_context: TODO do something with this parameter :)
         :returns: the document, its key, and associated context
         """
         item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
@@ -109,7 +108,7 @@ class DocumentBucketOperations:
         Stores a document in the Document Bucket system.
 
         :param data: the bytes of the document to store
-        :param context: the context for this document
+        :param context: TODO do something with this parameter :)
         :returns: the pointer reference for this document in the Document Bucket system
         """
         encrypted_data, header = aws_encryption_sdk.encrypt(

--- a/exercises/python/multi-cmk-start/src/document_bucket/config.py
+++ b/exercises/python/multi-cmk-start/src/document_bucket/config.py
@@ -6,6 +6,10 @@ import sys
 
 import toml
 
+"""
+Loads and maps configuration from the Document Bucket configuration system.
+"""
+
 _CONFIG_FILE = os.path.join(sys.prefix, "config", "config.toml")
 
 config = toml.load(_CONFIG_FILE)

--- a/exercises/python/multi-cmk-start/tox.ini
+++ b/exercises/python/multi-cmk-start/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 envlist=py38
 
+[testenv:docs]
+deps =
+    -rrequirements-doc.txt
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" doc "{toxworkdir}/docs_out" --color -W -bhtml {posargs}
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))'
+           python -m http.server --directory "{toxworkdir}/docs_out"
+
 [testenv:test]
 deps =
     -rrequirements-dev.txt


### PR DESCRIPTION
*Issue #, if available:* Partially addresses https://github.com/aws-samples/busy-engineers-document-bucket/issues/23

*Description of changes:* API docs, Sphinx configuration to build docs, and `tox` targets to generate and locally host docs.

Edit: Reviewer guidance:

* https://github.com/aws-samples/busy-engineers-document-bucket/pull/143/commits/c3e9491d85ffaba1c6e1b8369bfe86ecd8b71a7e has the core documentation
* https://github.com/aws-samples/busy-engineers-document-bucket/pull/143/commits/d261b4c16a68e27b44d2d80afd7f41dce357df82 has the first set of content removal for previous exercises
* https://github.com/aws-samples/busy-engineers-document-bucket/pull/143/commits/ccd018187b67fdd926819ef724a45c4b8894c441 has the other set of content removal for previous exercises

These are the 3 main diffs to review -- the rest is all duplicate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
