### PR TITLE
fix: clean up Java bootstrap makefile and move to new Maven mirror

### DIFF
--- a/exercises/java/Makefile
+++ b/exercises/java/Makefile
@@ -1,9 +1,12 @@
+MAVEN_VERSION = "3.6.3"
+
 bootstrap:
-	wget https://d3pxv6yz143wms.cloudfront.net/11.0.5.10.1/java-11-amazon-corretto-devel-11.0.5.10-1.x86_64.rpm -O /tmp/java-corretto.rpm
-	sudo yum install -y /tmp/java-corretto.rpm
+	sudo rpm --import https://yum.corretto.aws/corretto.key
+	sudo curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+	sudo yum install -y java-11-amazon-corretto-devel
 	sudo update-alternatives --set java /usr/lib/jvm/java-11-amazon-corretto/bin/java
 	java -version
-	wget http://apache.mirrors.lucidnetworks.net/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz -O /tmp/maven.tar.gz
+	wget http://mirror.cogentco.com/pub/apache/maven/maven-3/$(MAVEN_VERSION)/binaries/apache-maven-$(MAVEN_VERSION)-bin.tar.gz -O /tmp/maven.tar.gz
 	cd ~; tar xzvf /tmp/maven.tar.gz
-	sudo update-alternatives --install /usr/bin/mvn mvn ~/apache-maven-3.6.2/bin/mvn 0
+	sudo update-alternatives --install /usr/bin/mvn mvn ~/apache-maven-$(MAVEN_VERSION)/bin/mvn 0
 	mvn -version


### PR DESCRIPTION
*Issue #, if available:*
fixes: #177 

*Description of changes:*

1. Change to install Corretto via the yum repo per https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/generic-linux-install.html
1. Update Maven install to new Apache mirror per https://maven.apache.org/download.cgi and templatize the download/install to make moving to new versions simpler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
