### PR TITLE
chore: Upgrade checkstyles

### DIFF
--- a/exercises/java/add-esdk-complete/checkstyle.xml
+++ b/exercises/java/add-esdk-complete/checkstyle.xml
@@ -248,10 +248,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="scope" value="public"/>

--- a/exercises/java/add-esdk-start/checkstyle.xml
+++ b/exercises/java/add-esdk-start/checkstyle.xml
@@ -248,10 +248,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="scope" value="public"/>

--- a/exercises/java/encryption-context-complete/checkstyle.xml
+++ b/exercises/java/encryption-context-complete/checkstyle.xml
@@ -248,10 +248,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="scope" value="public"/>

--- a/exercises/java/encryption-context-start/checkstyle.xml
+++ b/exercises/java/encryption-context-start/checkstyle.xml
@@ -248,10 +248,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="scope" value="public"/>

--- a/exercises/java/encryption-context-start/pom.xml
+++ b/exercises/java/encryption-context-start/pom.xml
@@ -77,7 +77,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.26</version>
+                            <version>8.29</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/exercises/java/multi-cmk-complete/checkstyle.xml
+++ b/exercises/java/multi-cmk-complete/checkstyle.xml
@@ -248,10 +248,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="scope" value="public"/>

--- a/exercises/java/multi-cmk-complete/pom.xml
+++ b/exercises/java/multi-cmk-complete/pom.xml
@@ -77,7 +77,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.26</version>
+                            <version>8.29</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/exercises/java/multi-cmk-start/checkstyle.xml
+++ b/exercises/java/multi-cmk-start/checkstyle.xml
@@ -248,10 +248,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="scope" value="public"/>

--- a/exercises/java/multi-cmk-start/pom.xml
+++ b/exercises/java/multi-cmk-start/pom.xml
@@ -77,7 +77,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.26</version>
+                            <version>8.29</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
*Issue #, if available:* Upgrade all checkstyles to 8.29. Remove deprecated checkstyles properties.

*Description of changes:* manually testing according to https://github.com/aws-samples/busy-engineers-document-bucket#testing
also `mvn install` in every java exercise.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
