### PR TITLE
chore: Update Java example for the 2.0 Java ESDK release

### DIFF
--- a/exercises/java/encryption-context-complete/pom.xml
+++ b/exercises/java/encryption-context-complete/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <esdk.version>2.0.0</esdk.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-encryption-sdk-java</artifactId>
-            <version>1.6.1</version>
+            <version>${esdk.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -4,7 +4,6 @@
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
-import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
@@ -60,11 +59,8 @@ public class Api {
         tableName,
         s3Client,
         bucketName,
-        AwsCrypto.builder()
-            .withCommitmentPolicy(CommitmentPolicy.RequireEncryptRequireDecrypt)
-            .build(),
-        mkp
-    );
+        AwsCrypto.builder().build(),
+        mkp);
   }
 
   /**

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -4,6 +4,7 @@
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
@@ -54,7 +55,16 @@ public class Api {
       AmazonS3 s3Client,
       String bucketName,
       MasterKeyProvider mkp) {
-    this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
+    this(
+        ddbClient,
+        tableName,
+        s3Client,
+        bucketName,
+        AwsCrypto.builder()
+            .withCommitmentPolicy(CommitmentPolicy.RequireEncryptRequireDecrypt)
+            .build(),
+        mkp
+    );
   }
 
   /**

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -4,6 +4,7 @@
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
@@ -59,7 +60,9 @@ public class Api {
         tableName,
         s3Client,
         bucketName,
-        AwsCrypto.builder().build(),
+        AwsCrypto.builder()
+            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+            .build(),
         mkp);
   }
 

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/App.java
@@ -42,8 +42,7 @@ public class App {
     String walterCMK = stateConfig.contents.state.WalterCMK;
 
     // Set up the Master Key Provider to use KMS
-    KmsMasterKeyProvider mkp =
-        KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK, walterCMK).build();
+    KmsMasterKeyProvider mkp = KmsMasterKeyProvider.builder().buildStrict(faytheCMK, walterCMK);
 
     return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
   }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/busy-engineers-document-bucket/issues/204

*Description of changes:*
Primarily updates to account for API changes in ESDK 2.0, but also a minor change to pom.xml to make it easier to test against a specific ESDK version.

*Testing:* 
`mvn verify -Dcheckstyle.skip -Desdk.version=2.0.0` succeeds (previously failed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
