### PR TITLE
Upgrade Java examples and add codebuild

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,29 +1,20 @@
 version: 0.2
 
+env:
+  image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+
 batch:
   fast-fail: false
   build-list:
     - identifier: add_esdk_complete
       buildspec: codebuild/add-esdk-complete.yml
-      env:
-        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: add_esdk_start
       buildspec: codebuild/add-esdk-start.yml
-      env:
-        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: encryption_context_complete
       buildspec: codebuild/encryption-context-complete.yml
-      env:
-        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: encryption_context_start
       buildspec: codebuild/encryption-context-start.yml
-      env:
-        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: multi_cmk_complete
       buildspec: codebuild/multi-cmk-complete.yml
-      env:
-        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: multi_cmk_start
       buildspec: codebuild/multi-cmk-start.yml
-      env:
-        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,30 @@
+version: 0.2
+
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: add_esdk_complete
+      buildspec: codebuild/add_esdk_complete
+      env:
+        env:
+        image: aws/codebuild/standard:3.0
+    - identifier: add_esdk_start
+      buildspec: codebuild/add_esdk_start
+      env:
+        env:
+        image: aws/codebuild/standard:3.0
+    - identifier: encryption_context_complete
+      buildspec: codebuild/encryption_context_complete
+      env:
+        env:
+        image: aws/codebuild/standard:3.0
+    - identifier: encryption_context_start
+      buildspec: codebuild/encryption_context_start
+      env:
+        env:
+        image: aws/codebuild/standard:3.0
+    - identifier: multi_cmk_complete
+      buildspec: codebuild/multi_cmk_complete
+      env:
+        env:
+        image: aws/codebuild/standard:3.0

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,30 +6,24 @@ batch:
     - identifier: add_esdk_complete
       buildspec: codebuild/add-esdk-complete.yml
       env:
-        env:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: add_esdk_start
       buildspec: codebuild/add-esdk-start.yml
       env:
-        env:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: encryption_context_complete
       buildspec: codebuild/encryption-context-complete.yml
       env:
-        env:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: encryption_context_start
       buildspec: codebuild/encryption-context-start.yml
       env:
-        env:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: multi_cmk_complete
       buildspec: codebuild/multi-cmk-complete.yml
       env:
-        env:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: multi_cmk_start
       buildspec: codebuild/multi-cmk-start.yml
       env:
-        env:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,27 +4,32 @@ batch:
   fast-fail: false
   build-list:
     - identifier: add_esdk_complete
-      buildspec: codebuild/add_esdk_complete
+      buildspec: codebuild/add-esdk-complete.yml
       env:
         env:
-        image: aws/codebuild/standard:3.0
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: add_esdk_start
-      buildspec: codebuild/add_esdk_start
+      buildspec: codebuild/add-esdk-start.yml
       env:
         env:
-        image: aws/codebuild/standard:3.0
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: encryption_context_complete
-      buildspec: codebuild/encryption_context_complete
+      buildspec: codebuild/encryption-context-complete.yml
       env:
         env:
-        image: aws/codebuild/standard:3.0
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: encryption_context_start
-      buildspec: codebuild/encryption_context_start
+      buildspec: codebuild/encryption-context-start.yml
       env:
         env:
-        image: aws/codebuild/standard:3.0
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - identifier: multi_cmk_complete
-      buildspec: codebuild/multi_cmk_complete
+      buildspec: codebuild/multi-cmk-complete.yml
       env:
         env:
-        image: aws/codebuild/standard:3.0
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    - identifier: multi_cmk_start
+      buildspec: codebuild/multi-cmk-start.yml
+      env:
+        env:
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,8 +1,5 @@
 version: 0.2
 
-env:
-  image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-
 batch:
   fast-fail: false
   build-list:

--- a/codebuild/add-esdk-complete.yml
+++ b/codebuild/add-esdk-complete.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            java: corretto11
+    build:
+        commands:
+            - cd exercises/java/add-esdk-complete
+            - mvn install

--- a/codebuild/add-esdk-start.yml
+++ b/codebuild/add-esdk-start.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            java: corretto11
+    build:
+        commands:
+            - cd exercises/java/add-esdk-start
+            - mvn install

--- a/codebuild/encryption-context-complete.yml
+++ b/codebuild/encryption-context-complete.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            java: corretto11
+    build:
+        commands:
+            - cd exercises/java/encryption-context-complete
+            - mvn install

--- a/codebuild/encryption-context-start.yml
+++ b/codebuild/encryption-context-start.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            java: corretto11
+    build:
+        commands:
+            - cd exercises/java/encryption-context-start
+            - mvn install

--- a/codebuild/multi-cmk-complete.yml
+++ b/codebuild/multi-cmk-complete.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            java: corretto11
+    build:
+        commands:
+            - cd exercises/java/multi-cmk-complete
+            - mvn install

--- a/codebuild/multi-cmk-start.yml
+++ b/codebuild/multi-cmk-start.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+    install:
+        runtime-versions:
+            java: corretto11
+    build:
+        commands:
+            - cd exercises/java/multi-cmk-start
+            - mvn install

--- a/exercises/java/add-esdk-complete/pom.xml
+++ b/exercises/java/add-esdk-complete/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <esdk.version>2.2.0</esdk.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-encryption-sdk-java</artifactId>
-            <version>1.9.0</version>
+            <version>${esdk.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -5,6 +5,7 @@ package sfw.example.esdkworkshop;
 
 // ADD-ESDK-COMPLETE: Add the ESDK Dependency
 import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
@@ -58,14 +59,14 @@ public class Api {
       MasterKeyProvider mkp) {
     // ADD-ESDK-COMPLETE: Add the ESDK Dependency
     this(
-	    ddbClient,
-		tableName,
-		s3Client,
-		bucketName,
-		AwsCrypto.builder()
+        ddbClient,
+        tableName,
+        s3Client,
+        bucketName,
+        AwsCrypto.builder()
             .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
             .build(),
-		mkp);
+        mkp);
   }
 
   /**

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -57,7 +57,7 @@ public class Api {
       // ADD-ESDK-COMPLETE: Add the ESDK Dependency
       MasterKeyProvider mkp) {
     // ADD-ESDK-COMPLETE: Add the ESDK Dependency
-    this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
+    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
   }
 
   /**

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -57,7 +57,15 @@ public class Api {
       // ADD-ESDK-COMPLETE: Add the ESDK Dependency
       MasterKeyProvider mkp) {
     // ADD-ESDK-COMPLETE: Add the ESDK Dependency
-    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
+    this(
+	    ddbClient,
+		tableName,
+		s3Client,
+		bucketName,
+		AwsCrypto.builder()
+            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+            .build(),
+		mkp);
   }
 
   /**

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/App.java
@@ -43,8 +43,7 @@ public class App {
     String faytheCMK = stateConfig.contents.state.FaytheCMK;
 
     // Set up the Master Key Provider to use KMS
-    KmsMasterKeyProvider mkp =
-        KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK).build();
+    KmsMasterKeyProvider mkp = KmsMasterKeyProvider.builder().buildStrict(faytheCMK);
 
     return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
   }

--- a/exercises/java/add-esdk-start/pom.xml
+++ b/exercises/java/add-esdk-start/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <esdk.version>2.2.0</esdk.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-encryption-sdk-java</artifactId>
-            <version>1.6.1</version>
+            <version>${esdk.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -56,14 +56,14 @@ public class Api {
       String bucketName,
       MasterKeyProvider mkp) {
     this(
-	    ddbClient,
-		tableName,
-		s3Client,
-		bucketName,
-		AwsCrypto.builder()
+        ddbClient,
+        tableName,
+        s3Client,
+        bucketName,
+        AwsCrypto.builder()
             .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
             .build(),
-		mkp);
+        mkp);
   }
 
   /**

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -60,9 +60,7 @@ public class Api {
         tableName,
         s3Client,
         bucketName,
-        AwsCrypto.builder()
-            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
-            .build(),
+        AwsCrypto.standard(),
         mkp);
   }
 

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -56,12 +56,14 @@ public class Api {
       String bucketName,
       MasterKeyProvider mkp) {
     this(
-        ddbClient,
-        tableName,
-        s3Client,
-        bucketName,
-        AwsCrypto.standard(),
-        mkp);
+	    ddbClient,
+		tableName,
+		s3Client,
+		bucketName,
+		AwsCrypto.builder()
+            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+            .build(),
+		mkp);
   }
 
   /**

--- a/exercises/java/encryption-context-start/pom.xml
+++ b/exercises/java/encryption-context-start/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <esdk.version>2.2.0</esdk.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-encryption-sdk-java</artifactId>
-            <version>1.9.0</version>
+            <version>${esdk.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -53,7 +53,15 @@ public class Api {
       AmazonS3 s3Client,
       String bucketName,
       MasterKeyProvider mkp) {
-    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
+    this(
+	    ddbClient,
+		tableName,
+		s3Client,
+		bucketName,
+		AwsCrypto.builder()
+            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+            .build(),
+		mkp);
   }
 
   /**

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -53,7 +53,7 @@ public class Api {
       AmazonS3 s3Client,
       String bucketName,
       MasterKeyProvider mkp) {
-    this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
+    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
   }
 
   /**

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -4,6 +4,7 @@
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
@@ -54,14 +55,14 @@ public class Api {
       String bucketName,
       MasterKeyProvider mkp) {
     this(
-	    ddbClient,
-		tableName,
-		s3Client,
-		bucketName,
-		AwsCrypto.builder()
+        ddbClient,
+        tableName,
+        s3Client,
+        bucketName,
+        AwsCrypto.builder()
             .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
             .build(),
-		mkp);
+        mkp);
   }
 
   /**

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/App.java
@@ -42,8 +42,7 @@ public class App {
     String walterCMK = stateConfig.contents.state.WalterCMK;
 
     // Set up the Master Key Provider to use KMS
-    KmsMasterKeyProvider mkp =
-        KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK, walterCMK).build();
+    KmsMasterKeyProvider mkp = KmsMasterKeyProvider.builder().buildStrict(faytheCMK, walterCMK);
 
     return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
   }

--- a/exercises/java/multi-cmk-complete/pom.xml
+++ b/exercises/java/multi-cmk-complete/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <esdk.version>2.2.0</esdk.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-encryption-sdk-java</artifactId>
-            <version>1.6.1</version>
+            <version>${esdk.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -53,7 +53,15 @@ public class Api {
       AmazonS3 s3Client,
       String bucketName,
       MasterKeyProvider mkp) {
-    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
+    this(
+	    ddbClient,
+		tableName,
+		s3Client,
+		bucketName,
+		AwsCrypto.builder()
+            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+            .build(),
+		mkp);
   }
 
   /**

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -53,7 +53,7 @@ public class Api {
       AmazonS3 s3Client,
       String bucketName,
       MasterKeyProvider mkp) {
-    this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
+    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
   }
 
   /**

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -4,6 +4,7 @@
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
@@ -54,14 +55,14 @@ public class Api {
       String bucketName,
       MasterKeyProvider mkp) {
     this(
-	    ddbClient,
-		tableName,
-		s3Client,
-		bucketName,
-		AwsCrypto.builder()
+        ddbClient,
+        tableName,
+        s3Client,
+        bucketName,
+        AwsCrypto.builder()
             .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
             .build(),
-		mkp);
+        mkp);
   }
 
   /**

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/App.java
@@ -42,8 +42,7 @@ public class App {
     String walterCMK = stateConfig.contents.state.WalterCMK;
 
     // Set up the Master Key Provider to use KMS
-    KmsMasterKeyProvider mkp =
-        KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK, walterCMK).build();
+    KmsMasterKeyProvider mkp = KmsMasterKeyProvider.builder().buildStrict(faytheCMK, walterCMK);
 
     return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
   }

--- a/exercises/java/multi-cmk-start/pom.xml
+++ b/exercises/java/multi-cmk-start/pom.xml
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <esdk.version>2.2.0</esdk.version>
     </properties>
 
     <dependencies>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-encryption-sdk-java</artifactId>
-            <version>1.6.1</version>
+            <version>${esdk.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -53,7 +53,15 @@ public class Api {
       AmazonS3 s3Client,
       String bucketName,
       MasterKeyProvider mkp) {
-    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
+    this(
+	    ddbClient,
+		tableName,
+		s3Client,
+		bucketName,
+		AwsCrypto.builder()
+            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+            .build(),
+		mkp);
   }
 
   /**

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -53,7 +53,7 @@ public class Api {
       AmazonS3 s3Client,
       String bucketName,
       MasterKeyProvider mkp) {
-    this(ddbClient, tableName, s3Client, bucketName, new AwsCrypto(), mkp);
+    this(ddbClient, tableName, s3Client, bucketName, AwsCrypto.standard(), mkp);
   }
 
   /**

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -4,6 +4,7 @@
 package sfw.example.esdkworkshop;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CommitmentPolicy;
 import com.amazonaws.encryptionsdk.CryptoResult;
 import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
@@ -54,14 +55,14 @@ public class Api {
       String bucketName,
       MasterKeyProvider mkp) {
     this(
-	    ddbClient,
-		tableName,
-		s3Client,
-		bucketName,
-		AwsCrypto.builder()
+        ddbClient,
+        tableName,
+        s3Client,
+        bucketName,
+        AwsCrypto.builder()
             .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
             .build(),
-		mkp);
+        mkp);
   }
 
   /**

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/App.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/App.java
@@ -43,8 +43,7 @@ public class App {
 
     // Set up the Master Key Provider to use KMS
     // MULTI-CMK-START: Add Walter to the CMKs to Use
-    KmsMasterKeyProvider mkp =
-        KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK).build();
+    KmsMasterKeyProvider mkp = KmsMasterKeyProvider.builder().buildStrict(faytheCMK);
 
     return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
   }


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Bring all the Java exercises up to the latest ESDK for Java version.
Also add codebuild to test each Java step in CI.

Note: Descriptions at https://document-bucket.awssecworkshops.com/adding-the-encryption-sdk/ are out of date with references to some of the code (and were before this PR)

Note: The CI only builds each step of the workshop for Java. We still have no CI for the other languages, or any of the workshop CFn/cdk stuff.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
