### PR TITLE
fix: Fix code block tabs using latest mkdocs

### DIFF
--- a/instructions/docs/adding-the-encryption-sdk.md
+++ b/instructions/docs/adding-the-encryption-sdk.md
@@ -14,21 +14,29 @@ Now you will add the AWS Encryption SDK to encrypt objects on the client, before
 
 Make sure you are in the `exercises` directory for the language of your choice:
 
-```bash tab="Java"
-cd ~/environment/workshop/exercises/java/add-esdk-start
-```
+=== "Java"
 
-```bash tab="Typescript Node.JS"
-cd ~/environment/workshop/exercises/node-typescript/add-esdk-start
-```
-
-```bash tab="JavaScript Node.JS"
-cd ~/environment/workshop/exercises/node-javascript/add-esdk-start
-```
-
-```bash tab="Python"
-cd ~/environment/workshop/exercises/python/add-esdk-start
-```
+    ```bash
+    cd ~/environment/workshop/exercises/java/add-esdk-start
+    ```
+    
+=== "Typescript Node.JS"
+    
+    ```bash
+    cd ~/environment/workshop/exercises/node-typescript/add-esdk-start
+    ```
+    
+=== "JavaScript Node.JS"
+    
+    ```bash
+    cd ~/environment/workshop/exercises/node-javascript/add-esdk-start
+    ```
+    
+=== "Python"
+    
+    ```bash
+    cd ~/environment/workshop/exercises/python/add-esdk-start
+    ```
 
 ### Step 1: Add the ESDK Dependency
 
@@ -36,118 +44,126 @@ Look for `ADD-ESDK-START` comments in the code to help orient yourself.
 
 Start by adding the Encryption SDK dependency to the code.
 
-```java tab="Java" hl_lines="5 6 7 8 9 15 16 26 31 32 40"
-// Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
-package sfw.example.esdkworkshop;
+=== "Java"
 
-// ADD-ESDK-START: Add the ESDK Dependency
-import com.amazonaws.encryptionsdk.AwsCrypto;
-import com.amazonaws.encryptionsdk.CryptoResult;
-import com.amazonaws.encryptionsdk.MasterKey;
-import com.amazonaws.encryptionsdk.MasterKeyProvider;
-import com.amazonaws.encryptionsdk.kms.KmsMasterKey;
+    ```{.java hl_lines="5 6 7 8 9 15 16 26 31 32 40"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
+    package sfw.example.esdkworkshop;
 
-...
-private final String tableName;
-private final String bucketName;
-// ADD-ESDK-START: Add the ESDK Dependency
-private final AwsCrypto awsEncryptionSdk;
-private final MasterKeyProvider mkp;
-
-...
-
-public Api(
-    AmazonDynamoDB ddbClient,
-    String tableName,
-    AmazonS3 s3Client,
-    String bucketName,
     // ADD-ESDK-START: Add the ESDK Dependency
-    MasterKeyProvider<? extends MasterKey> mkp) {
-  this.ddbClient = ddbClient;
-  this.tableName = tableName;
-  this.s3Client = s3Client
-  // ADD-ESDK-START: Add the ESDK Dependency
-  this.awsEncryptionSdk = new AwsCrypto();
-  this.mkp = mkp;
-}
+    import com.amazonaws.encryptionsdk.AwsCrypto;
+    import com.amazonaws.encryptionsdk.CryptoResult;
+    import com.amazonaws.encryptionsdk.MasterKey;
+    import com.amazonaws.encryptionsdk.MasterKeyProvider;
+    import com.amazonaws.encryptionsdk.kms.KmsMasterKey;
 
-// Save and close.
-// Edit ./src/main/java/sfw/example/esdkworkshop/App.java
-package sfw.example.esdkworkshop;
+    ...
+    private final String tableName;
+    private final String bucketName;
+    // ADD-ESDK-START: Add the ESDK Dependency
+    private final AwsCrypto awsEncryptionSdk;
+    private final MasterKeyProvider mkp;
 
-// ADD-ESDK-START: Add the ESDK Dependency
-import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
-// Save and close.
-```
+    ...
 
-```typescript tab="Typescript Node.JS" hl_lines="4 11"
-// Edit ./src/store.ts
+    public Api(
+        AmazonDynamoDB ddbClient,
+        String tableName,
+        AmazonS3 s3Client,
+        String bucketName,
+        // ADD-ESDK-START: Add the ESDK Dependency
+        MasterKeyProvider<? extends MasterKey> mkp) {
+    this.ddbClient = ddbClient;
+    this.tableName = tableName;
+    this.s3Client = s3Client
+    // ADD-ESDK-START: Add the ESDK Dependency
+    this.awsEncryptionSdk = new AwsCrypto();
+    this.mkp = mkp;
+    }
 
-// ADD-ESDK-START: Add the ESDK Dependency
-import { KmsKeyringNode, buildClient, CommitmentPolicy } from "@aws-crypto/client-node";
-const { encryptStream } = buildClient(
-    CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-)
+    // Save and close.
+    // Edit ./src/main/java/sfw/example/esdkworkshop/App.java
+    package sfw.example.esdkworkshop;
 
-// Save and exit
+    // ADD-ESDK-START: Add the ESDK Dependency
+    import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
+    // Save and close.
+    ```
 
-// Edit ./src/retrieve.ts
+=== "Typescript Node.JS"
 
-// ADD-ESDK-START: Add the ESDK Dependency
-import { KmsKeyringNode, buildClient, CommitmentPolicy } from "@aws-crypto/client-node";
-const { decryptStream } = buildClient(
-    CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-)
+    ```{.typescript hl_lines="4 5 6 7 14 15 16 17"}
+    // Edit ./src/store.ts
 
-// Save and exit
-```
+    // ADD-ESDK-START: Add the ESDK Dependency
+    import { KmsKeyringNode, buildClient, CommitmentPolicy } from "@aws-crypto/client-node";
+    const { encryptStream } = buildClient(
+        CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+    )
 
-```javascript tab="JavaScript Node.JS" hl_lines="4 11"
-// Edit ./store.js
+    // Save and exit
 
-// ADD-ESDK-START: Add the ESDK Dependency
-const { KmsKeyringNode, buildClient, CommitmentPolicy } = require("@aws-crypto/client-node");
-const { encryptStream } = buildClient(
-    CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-)
+    // Edit ./src/retrieve.ts
 
-// Save and exit
+    // ADD-ESDK-START: Add the ESDK Dependency
+    import { KmsKeyringNode, buildClient, CommitmentPolicy } from "@aws-crypto/client-node";
+    const { decryptStream } = buildClient(
+        CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+    )
 
-// Edit ./retrieve.js
+    // Save and exit
+    ```
 
-// ADD-ESDK-START: Add the ESDK Dependency
-const { KmsKeyringNode, buildClient, CommitmentPolicy } = require("@aws-crypto/client-node");
-const { decryptStream } = buildClient(
-    CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-)
+=== "JavaScript Node.JS"
 
-// Save and exit
-```
+    ```{.javascript hl_lines="4 5 6 7 14 15 16 17"}
+    // Edit ./store.js
 
-```python tab="Python" hl_lines="4 10 11 15 19"
-# Edit src/document_bucket/__init__.py
+    // ADD-ESDK-START: Add the ESDK Dependency
+    const { KmsKeyringNode, buildClient, CommitmentPolicy } = require("@aws-crypto/client-node");
+    const { encryptStream } = buildClient(
+        CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+    )
 
-# ADD-ESDK-START: Add the ESDK Dependency
-import aws_encryption_sdk
+    // Save and exit
 
-# Save and exit
-# Edit src/document_bucket/api.py
+    // Edit ./retrieve.js
 
-# ADD-ESDK-START: Add the ESDK Dependency
-import aws_encryption_sdk
-from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider  # type: ignore
-from aws_encryption_sdk.identifiers import CommitmentPolicy
+    // ADD-ESDK-START: Add the ESDK Dependency
+    const { KmsKeyringNode, buildClient, CommitmentPolicy } = require("@aws-crypto/client-node");
+    const { decryptStream } = buildClient(
+        CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+    )
 
-# Add a Master Key Provider to your __init__
-# ADD-ESDK-START: Add the ESDK Dependency
-def __init__(self, bucket, table, master_key_provider: StrictAwsKmsMasterKeyProvider):
-    self.bucket = bucket
-    self.table = table
+    // Save and exit
+    ```
+
+=== "Python"
+
+    ```{.python hl_lines="4 10 11 12 16 20"}
+    # Edit src/document_bucket/__init__.py
+
     # ADD-ESDK-START: Add the ESDK Dependency
-    self.master_key_provider : StrictAwsKmsMasterKeyProvider = master_key_provider
+    import aws_encryption_sdk
 
-# Save and exit
-```
+    # Save and exit
+    # Edit src/document_bucket/api.py
+
+    # ADD-ESDK-START: Add the ESDK Dependency
+    import aws_encryption_sdk
+    from aws_encryption_sdk import StrictAwsKmsMasterKeyProvider  # type: ignore
+    from aws_encryption_sdk.identifiers import CommitmentPolicy
+
+    # Add a Master Key Provider to your __init__
+    # ADD-ESDK-START: Add the ESDK Dependency
+    def __init__(self, bucket, table, master_key_provider: StrictAwsKmsMasterKeyProvider):
+        self.bucket = bucket
+        self.table = table
+        # ADD-ESDK-START: Add the ESDK Dependency
+        self.master_key_provider : StrictAwsKmsMasterKeyProvider = master_key_provider
+
+    # Save and exit
+    ```
 
 #### What Happened?
 
@@ -158,52 +174,60 @@ def __init__(self, bucket, table, master_key_provider: StrictAwsKmsMasterKeyProv
 
 Now that you have the AWS Encryption SDK imported, start encrypting your data before storing it.
 
-```java tab="Java" hl_lines="4 5 6"
-// Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
-public PointerItem store(byte[] data, Map<String, String> context) {
+=== "Java"
+
+    ```{.java hl_lines="4 5 6"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
+    public PointerItem store(byte[] data, Map<String, String> context) {
+        // ADD-ESDK-START: Add Encryption to store
+        CryptoResult<byte[], KmsMasterKey> encryptedMessage = awsEncryptionSdk.encryptData(mkp, data);
+        DocumentBundle bundle =
+            DocumentBundle.fromDataAndContext(encryptedMessage.getResult(), context);
+        writeItem(bundle.getPointer());
+        ...
+    ```
+
+=== "Typescript Node.JS"
+
+    ```{.typescript hl_lines="4"}
+    // Edit ./src/store.ts
+
     // ADD-ESDK-START: Add Encryption to store
-    CryptoResult<byte[], KmsMasterKey> encryptedMessage = awsEncryptionSdk.encryptData(mkp, data);
-    DocumentBundle bundle =
-        DocumentBundle.fromDataAndContext(encryptedMessage.getResult(), context);
-    writeItem(bundle.getPointer());
-    ...
-```
+    const Body = fileStream.pipe(encryptStream(encryptKeyring));
 
-```typescript tab="Typescript Node.JS" hl_lines="4"
-// Edit ./src/store.ts
+    // Save and exit
 
-// ADD-ESDK-START: Add Encryption to store
-const Body = fileStream.pipe(encryptStream(encryptKeyring));
+    ```
 
-// Save and exit
+=== "JavaScript Node.JS"
 
-```
+    ```{.javascript hl_lines="4"}
+    // Edit ./store.js
 
-```javascript tab="JavaScript Node.JS" hl_lines="4"
-// Edit ./store.js
+    // ADD-ESDK-START: Add Encryption to store
+    const Body = fileStream.pipe(encryptStream(encryptKeyring));
 
-// ADD-ESDK-START: Add Encryption to store
-const Body = fileStream.pipe(encryptStream(encryptKeyring));
+    // Save and exit
 
-// Save and exit
+    ```
 
-```
+=== "Python"
 
-```python tab="Python" hl_lines="5 6 7 8 10"
-# Edit src/document_bucket/api.py
-# Find the store function and edit it to add the Master Key Provider
-# and to write the encrypted data
-    # ADD-ESDK-START: Add Encryption to store
-    client = aws_encryption_sdk.EncryptionSDKClient(
-        commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-    )
-    encrypted_data, header = client.encrypt(
-        source=data,
-        key_provider=self.master_key_provider,
-    )
-    ...
-    self._write_object(encrypted_data, item)
-```
+    ```{.python hl_lines="5 6 7 8 9 10 11 13"}
+    # Edit src/document_bucket/api.py
+    # Find the store function and edit it to add the Master Key Provider
+    # and to write the encrypted data
+        # ADD-ESDK-START: Add Encryption to store
+        client = aws_encryption_sdk.EncryptionSDKClient(
+            commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+        )
+        encrypted_data, header = client.encrypt(
+            source=data,
+            key_provider=self.master_key_provider,
+        )
+        ...
+        self._write_object(encrypted_data, item)
+    ```
 
 #### What Happened?
 
@@ -219,60 +243,67 @@ The application will use the AWS Encryption SDK to encrypt your data client-side
 
 Now that the application encypts your data before storing it, it will need to decrypt your data before returning it to the caller (at least for the data to be useful, anyway).
 
-```java tab="Java" hl_lines="5 7"
-// Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
-// Find retrieve(...)
-    byte[] data = getObjectData(key);
+=== "Java"
+
+    ```{.java hl_lines="5 7"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
+    // Find retrieve(...)
+        byte[] data = getObjectData(key);
+        // ADD-ESDK-START: Add Decryption to retrieve
+        CryptoResult<byte[], KmsMasterKey> decryptedMessage = awsEncryptionSdk.decryptData(mkp, data);
+        ...
+        return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
+    ```
+
+=== "Typescript Node.JS"
+
+    ```{.typescript hl_lines="7"}
+    // Edit ./src/retrieve.ts
+
     // ADD-ESDK-START: Add Decryption to retrieve
-    CryptoResult<byte[], KmsMasterKey> decryptedMessage = awsEncryptionSdk.decryptData(mkp, data);
-    ...
-    return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
-```
+    return s3
+        .getObject({ Bucket, Key })
+        .createReadStream()
+        .pipe(decryptStream(decryptKeyring));
 
+    // Save and Exit
+    ```
 
-```typescript tab="Typescript Node.JS" hl_lines="7"
-// Edit ./src/retrieve.ts
+=== "JavaScript Node.JS"
 
-  // ADD-ESDK-START: Add Decryption to retrieve
-  return s3
-    .getObject({ Bucket, Key })
-    .createReadStream()
-    .pipe(decryptStream(decryptKeyring));
+    ```{.javascript hl_lines="7"}
+    // Edit ./retrieve.js
 
-// Save and Exit
-```
+    // ADD-ESDK-START: Add Decryption to retrieve
+    return s3
+        .getObject({ Bucket, Key })
+        .createReadStream()
+        .pipe(decryptStream(decryptKeyring));
 
-```javascript tab="JavaScript Node.JS" hl_lines="7"
-// Edit ./retrieve.js
+    // Save and Exit
+    ```
 
-  // ADD-ESDK-START: Add Decryption to retrieve
-  return s3
-    .getObject({ Bucket, Key })
-    .createReadStream()
-    .pipe(decryptStream(decryptKeyring));
+=== "Python"
 
-// Save and Exit
-```
+    ```{.python hl_lines="6 7 8 9 10 11 12 14"}
+    # Edit src/document_bucket/api.py
+    # Find the retrieve function and edit it to add a call to decrypt the
+    # encrypted data before returning it
+            item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
+            # ADD-ESDK-START: Add Decryption to retrieve
+            encrypted_data = self._get_object(item)
+            client = aws_encryption_sdk.EncryptionSDKClient(
+                commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+            )
+            plaintext, header = client.decrypt(
+                source=encrypted_data, key_provider=self.master_key_provider
+            )
+            return DocumentBundle.from_data_and_context(
+                plaintext, item.context
+            )
 
-```python tab="Python" hl_lines="6 7 8 9 11"
-# Edit src/document_bucket/api.py
-# Find the retrieve function and edit it to add a call to decrypt the
-# encrypted data before returning it
-        item = self._get_pointer_item(PointerQuery.from_key(pointer_key))
-        # ADD-ESDK-START: Add Decryption to retrieve
-        encrypted_data = self._get_object(item)
-        client = aws_encryption_sdk.EncryptionSDKClient(
-            commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-        )
-        plaintext, header = client.decrypt(
-            source=encrypted_data, key_provider=self.master_key_provider
-        )
-        return DocumentBundle.from_data_and_context(
-            plaintext, item.context
-        )
-
-# Save and exit
-```
+    # Save and exit
+    ```
 
 #### What Happened?
 
@@ -290,80 +321,88 @@ The data returned from S3 for `retrieve` is encrypted. Before returning that dat
 
 Now that you have declared your dependencies and updated your code to encrypt and decrypt data, the final step is to pass through the configuration to the AWS Encryption SDK to start using your KMS CMKs to protect your data.
 
-```java tab="Java" hl_lines="6 9 10 12"
-// Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
-    AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
+=== "Java"
+
+    ```{.java hl_lines="6 9 10 12"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
+        AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
+
+        // ADD-ESDK-START: Configure the Faythe CMK in the Encryption SDK
+        // Load configuration of KMS resources
+        String faytheCMK = stateConfig.contents.state.FaytheCMK;
+
+        // Set up the Master Key Provider to use KMS
+        KmsMasterKeyProvider mkp =
+            KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK).build();
+
+        return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
+    ```
+
+=== "Typescript Node.JS"
+
+    ```{.typescript hl_lines="4 5 6 7 14 15"}
+
+    // Edit ./src/store.ts
 
     // ADD-ESDK-START: Configure the Faythe CMK in the Encryption SDK
-    // Load configuration of KMS resources
-    String faytheCMK = stateConfig.contents.state.FaytheCMK;
+    const faytheCMK = config.state.getFaytheCMK();
+    const encryptKeyring = new KmsKeyringNode({
+    generatorKeyId: faytheCMK
+    });
 
-    // Set up the Master Key Provider to use KMS
-    KmsMasterKeyProvider mkp =
-        KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK).build();
+    // Save and exit
 
-    return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
-```
+    // Edit ./src/retrieve.ts
 
-```typescript tab="Typescript Node.JS"  hl_lines="4 5 6 7 14 15"
+    // ADD-ESDK-START: Set up a keyring to use Faythe's CMK for decrypting.
+    const faytheCMK = config.state.getFaytheCMK();
+    const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK] });
 
-// Edit ./src/store.ts
+    // Save and exit
+    ```
 
-// ADD-ESDK-START: Configure the Faythe CMK in the Encryption SDK
-const faytheCMK = config.state.getFaytheCMK();
-const encryptKeyring = new KmsKeyringNode({
-  generatorKeyId: faytheCMK
-});
+=== "JavaScript Node.JS"
 
-// Save and exit
+    ```{.javascript hl_lines="4 5 6 7 14 15"}
 
-// Edit ./src/retrieve.ts
+    // Edit ./store.js
 
-// ADD-ESDK-START: Set up a keyring to use Faythe's CMK for decrypting.
-const faytheCMK = config.state.getFaytheCMK();
-const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK] });
+    // ADD-ESDK-START: Configure the Faythe CMK in the Encryption SDK
+    const faytheCMK = config.state.getFaytheCMK();
+    const encryptKeyring = new KmsKeyringNode({
+    generatorKeyId: faytheCMK
+    });
 
-// Save and exit
-```
+    // Save and exit
 
-```javascript tab="JavaScript Node.JS"  hl_lines="4 5 6 7 14 15"
+    // Edit ./retrieve.js
 
-// Edit ./store.js
+    // ADD-ESDK-START: Set up a keyring to use Faythe's CMK for decrypting.
+    const faytheCMK = config.state.getFaytheCMK();
+    const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK] });
 
-// ADD-ESDK-START: Configure the Faythe CMK in the Encryption SDK
-const faytheCMK = config.state.getFaytheCMK();
-const encryptKeyring = new KmsKeyringNode({
-  generatorKeyId: faytheCMK
-});
+    // Save and exit
+    ```
 
-// Save and exit
+=== "Python"
 
-// Edit ./retrieve.js
+    ```{.python hl_lines="7 9 10 12"}
 
-// ADD-ESDK-START: Set up a keyring to use Faythe's CMK for decrypting.
-const faytheCMK = config.state.getFaytheCMK();
-const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK] });
+    # Edit src/document_bucket/__init__.py
 
-// Save and exit
-```
+    ...
 
-```python tab="Python" hl_lines="7 9 10 12"
+    # ADD-ESDK-START: Configure the Faythe CMK in the Encryption SDK
+    # Pull configuration of KMS resources
+    faythe_cmk = state["FaytheCMK"]
+    # And the Master Key Provider configuring how to use KMS
+    cmk = [faythe_cmk]
+    mkp = aws_encryption_sdk.StrictAwsKmsMasterKeyProvider(key_ids=cmk)
 
-# Edit src/document_bucket/__init__.py
+    operations = DocumentBucketOperations(bucket, table, mkp)
 
-...
-
-# ADD-ESDK-START: Configure the Faythe CMK in the Encryption SDK
-# Pull configuration of KMS resources
-faythe_cmk = state["FaytheCMK"]
-# And the Master Key Provider configuring how to use KMS
-cmk = [faythe_cmk]
-mkp = aws_encryption_sdk.StrictAwsKmsMasterKeyProvider(key_ids=cmk)
-
-operations = DocumentBucketOperations(bucket, table, mkp)
-
-# Save and exit
-```
+    # Save and exit
+    ```
 
 #### What Happened?
 
@@ -377,21 +416,29 @@ Want to check your progress, or compare what you've done versus a finished examp
 
 Check out the code in one of the `-complete` folders to compare.
 
-```bash tab="Java"
-cd ~/environment/workshop/exercises/java/add-esdk-complete
-```
+=== "Java"
 
-```bash tab="Typescript Node.JS"
-cd ~/environment/workshop/exercises/node-typescript/add-esdk-complete
-```
+    ```bash 
+    cd ~/environment/workshop/exercises/java/add-esdk-complete
+    ```
 
-```bash tab="JavaScript Node.JS"
-cd ~/environment/workshop/exercises/node-javascript/add-esdk-complete
-```
+=== "Typescript Node.JS"
 
-```bash tab="Python"
-cd ~/environment/workshop/exercises/python/add-esdk-complete
-```
+    ```bash
+    cd ~/environment/workshop/exercises/node-typescript/add-esdk-complete
+    ```
+
+=== "JavaScript Node.JS"
+
+    ```bash
+    cd ~/environment/workshop/exercises/node-javascript/add-esdk-complete
+    ```
+
+=== "Python"
+
+    ```bash
+    cd ~/environment/workshop/exercises/python/add-esdk-complete
+    ```
 
 ## Try it Out
 
@@ -409,86 +456,98 @@ To get started, here are some things to try:
 
 For more things to try, check out [Explore Further](#explore-further), below.
 
-```java tab="Java"
-// Compile your code
-mvn compile
+=== "Java"
 
-// To use the API programmatically, use this target to launch jshell
-mvn jshell:run
-/open startup.jsh
-Api documentBucket = App.initializeDocumentBucket();
-documentBucket.list();
-documentBucket.store("Store me in the Document Bucket!".getBytes());
-for (PointerItem item : documentBucket.list()) {
-    DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS());
-    System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
-}
-// Ctrl+D to exit jshell
+    ```java
+    // Compile your code
+    mvn compile
 
-// Or, to run logic that you write in App.java, use this target after compile
-mvn exec:java
-```
+    // To use the API programmatically, use this target to launch jshell
+    mvn jshell:run
+    /open startup.jsh
+    Api documentBucket = App.initializeDocumentBucket();
+    documentBucket.list();
+    documentBucket.store("Store me in the Document Bucket!".getBytes());
+    for (PointerItem item : documentBucket.list()) {
+        DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS());
+        System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
+    }
+    // Ctrl+D to exit jshell
 
-```javascript tab="JavaScript Node.JS"
-node
-list = require("./list.js")
-store = require("./store.js")
-retrieve = require("./retrieve")
-list().then(console.log)
-store(fs.createReadStream("./store.js")).then(r => {
-  // Just storing the s3 key
-  key = r.Key
-  console.log(r)
-})
-list().then(console.log)
-(() => {retrieve("PutYourKeyValue").pipe(process.stdout)})()
-// Ctrl-D when finished to exit the REPL
-```
+    // Or, to run logic that you write in App.java, use this target after compile
+    mvn exec:java
+    ```
 
-```bash tab="JavaScript Node.JS CLI"
-./cli.js list
-./cli.js store ./store.js
-# Note the "Key" value
-./cli.js list
-# Note the "reference" value
-./cli.js retrieve $KeyOrReferenceValue
-```
+=== "JavaScript Node.JS"
 
-```typescript tab="Typescript Node.JS"
-node -r ts-node/register
-;({list} = require("./src/list.ts"))
-;({store} = require("./src/store.ts"))
-;({retrieve} = require("./src/retrieve.ts"))
-list().then(console.log)
-store(fs.createReadStream("./src/store.ts")).then(r => {
-  // Just storing the s3 key
-  key = r.Key
-  console.log(r)
-})
-list().then(console.log)
-(() => {retrieve("PutYourKeyValue").pipe(process.stdout)})()
-// Ctrl-D when finished to exit the REPL
-```
+    ```javascript
+    node
+    list = require("./list.js")
+    store = require("./store.js")
+    retrieve = require("./retrieve")
+    list().then(console.log)
+    store(fs.createReadStream("./store.js")).then(r => {
+    // Just storing the s3 key
+    key = r.Key
+    console.log(r)
+    })
+    list().then(console.log)
+    (() => {retrieve("PutYourKeyValue").pipe(process.stdout)})()
+    // Ctrl-D when finished to exit the REPL
+    ```
 
-```bash tab="Typescript Node.JS CLI"
-./cli.ts list
-./cli.ts store ./store.js
-# Note the "Key" value
-./cli.ts list
-# Note the "reference" value
-./cli.ts retrieve $KeyOrReferenceValue
-```
+=== "JavaScript Node.JS CLI"
 
-```python tab="Python"
-tox -e repl
-import document_bucket
-ops = document_bucket.initialize()
-ops.list()
-ops.store(b'some data')
-ops.list()
-ops.retrieve("PutYourKeyHere").data
-# Ctrl-D when finished to exit the REPL
-```
+    ```bash
+    ./cli.js list
+    ./cli.js store ./store.js
+    # Note the "Key" value
+    ./cli.js list
+    # Note the "reference" value
+    ./cli.js retrieve $KeyOrReferenceValue
+    ```
+
+=== "Typescript Node.JS"
+
+    ```typescript
+    node -r ts-node/register
+    ;({list} = require("./src/list.ts"))
+    ;({store} = require("./src/store.ts"))
+    ;({retrieve} = require("./src/retrieve.ts"))
+    list().then(console.log)
+    store(fs.createReadStream("./src/store.ts")).then(r => {
+    // Just storing the s3 key
+    key = r.Key
+    console.log(r)
+    })
+    list().then(console.log)
+    (() => {retrieve("PutYourKeyValue").pipe(process.stdout)})()
+    // Ctrl-D when finished to exit the REPL
+    ```
+
+=== "Typescript Node.JS CLI"
+
+    ```bash
+    ./cli.ts list
+    ./cli.ts store ./store.js
+    # Note the "Key" value
+    ./cli.ts list
+    # Note the "reference" value
+    ./cli.ts retrieve $KeyOrReferenceValue
+    ```
+
+=== "Python"
+
+    ```python
+    tox -e repl
+    import document_bucket
+    ops = document_bucket.initialize()
+    ops.list()
+    ops.store(b'some data')
+    ops.list()
+    ops.retrieve("PutYourKeyHere").data
+    # Ctrl-D when finished to exit the REPL
+    ```
 
 ## Explore Further
 

--- a/instructions/docs/encryption-context.md
+++ b/instructions/docs/encryption-context.md
@@ -71,66 +71,82 @@ If you just finished [Using Multiple CMKs](./multi-cmk.md), you are all set.
 
 If you aren't sure, or want to catch up, jump into the `encryption-context-start` directory for the language of your choice.
 
-```bash tab="Java"
-cd ~/environment/workshop/exercises/java/encryption-context-start
-```
+=== "Java"
 
-```bash tab="JavaScript Node.JS"
-cd ~/environment/workshop/exercises/node-javascript/encryption-context-start
-```
+    ```bash 
+    cd ~/environment/workshop/exercises/java/encryption-context-start
+    ```
 
-```bash tab="Typescript Node.JS"
-cd ~/environment/workshop/exercises/node-typescript/encryption-context-start
-```
+=== "JavaScript Node.JS"
 
-```bash tab="Python"
-cd ~/environment/workshop/exercises/python/encryption-context-start
-```
+    ```bash
+    cd ~/environment/workshop/exercises/node-javascript/encryption-context-start
+    ```
+
+=== "Typescript Node.JS"
+
+    ```bash
+    cd ~/environment/workshop/exercises/node-typescript/encryption-context-start
+    ```
+
+=== "Python"
+
+    ```bash
+    cd ~/environment/workshop/exercises/python/encryption-context-start
+    ```
 
 ### Step 1: Set Encryption Context on Encrypt
 
-```java tab="Java" hl_lines="4"
-// Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find store(...)
-    // ENCRYPTION-CONTEXT-START: Set Encryption Context on Encrypt
-    CryptoResult<byte[], KmsMasterKey> encryptedMessage =
-        awsEncryptionSdk.encryptData(mkp, data, context);
-    DocumentBundle bundle =
-        DocumentBundle.fromDataAndContext(encryptedMessage.getResult(), context);
-// Save your changes
-```
+=== "Java"
 
-```javascript tab="JavaScript Node.JS" hl_lines="3 4 5"
-  // Edit ./store.js
-  // ENCRYPTION-CONTEXT-START: Set encryption context on Encrypt
-  const Body = fileStream.pipe(
-    encryptStream(encryptKeyring, { encryptionContext })
-  );
+    ```{.java hl_lines="4"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find store(...)
+        // ENCRYPTION-CONTEXT-START: Set Encryption Context on Encrypt
+        CryptoResult<byte[], KmsMasterKey> encryptedMessage =
+            awsEncryptionSdk.encryptData(mkp, data, context);
+        DocumentBundle bundle =
+            DocumentBundle.fromDataAndContext(encryptedMessage.getResult(), context);
+    // Save your changes
+    ```
 
-// Save your changes
-```
+=== "JavaScript Node.JS"
 
-```typescript tab="Typescript Node.JS" hl_lines="3 4 5"
-  // Edit ./src/store.ts
-  // ENCRYPTION-CONTEXT-START: Set encryption context on Encrypt
-  const Body = fileStream.pipe(
-    encryptStream(encryptKeyring, { encryptionContext })
-  );
+    ```{.javascript hl_lines="3 4 5"}
+      // Edit ./store.js
+      // ENCRYPTION-CONTEXT-START: Set encryption context on Encrypt
+      const Body = fileStream.pipe(
+        encryptStream(encryptKeyring, { encryptionContext })
+      );
 
-// Save your changes
-```
+    // Save your changes
+    ```
 
-```python tab="Python" hl_lines="8"
-# Edit src/document_bucket/api.py
-# Find the store(...) function, and add context to the encrypt call
+=== "Typescript Node.JS"
 
-# ENCRYPTION-CONTEXT-START: Set encryption context on Encrypt
-encrypted_data, header = aws_encryption_sdk.encrypt(
-    source=data,
-    key_provider=self.master_key_provider,
-    encryption_context=context,
-)
-# Save your changes
-```
+    ```{.typescript hl_lines="3 4 5"}
+      // Edit ./src/store.ts
+      // ENCRYPTION-CONTEXT-START: Set encryption context on Encrypt
+      const Body = fileStream.pipe(
+        encryptStream(encryptKeyring, { encryptionContext })
+      );
+
+    // Save your changes
+    ```
+
+=== "Python"
+
+    ```{.python hl_lines="8"}
+    # Edit src/document_bucket/api.py
+    # Find the store(...) function, and add context to the encrypt call
+
+    # ENCRYPTION-CONTEXT-START: Set encryption context on Encrypt
+    encrypted_data, header = aws_encryption_sdk.encrypt(
+        source=data,
+        key_provider=self.master_key_provider,
+        encryption_context=context,
+    )
+    # Save your changes
+    ```
 
 #### What Happened?
 
@@ -146,61 +162,69 @@ Next you will update `retrieve` to use the encryption context on decrypt.
 
 ### Step 2: Use Encryption Context on Decrypt
 
-```java tab="Java" hl_lines="3 4"
-// Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find retrieve(...)
-    // ENCRYPTION-CONTEXT-START: Use Encryption Context on Decrypt
-    Map<String, String> actualContext = decryptedMessage.getEncryptionContext();
-    PointerItem pointer = PointerItem.fromKeyAndContext(key, actualContext);
-// Save your changes
-```
+=== "Java"
 
-```javascript tab="JavaScript Node.JS" hl_lines="9 10 11"
-// Edit ./retrieve.js
+    ```{.java hl_lines="3 4"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find retrieve(...)
+        // ENCRYPTION-CONTEXT-START: Use Encryption Context on Decrypt
+        Map<String, String> actualContext = decryptedMessage.getEncryptionContext();
+        PointerItem pointer = PointerItem.fromKeyAndContext(key, actualContext);
+    // Save your changes
+    ```
 
-  return (
-    s3
-      .getObject({ Bucket, Key })
-      .createReadStream()
-      .pipe(decryptStream(decryptKeyring))
-      // ENCRYPTION-CONTEXT-START: Making Assertions
-      .once("MessageHeader", function(header) {
+=== "JavaScript Node.JS"
 
-      })
-  );
+    ```{.javascript hl_lines="9 10 11"}
+    // Edit ./retrieve.js
 
-// Save your changes
+      return (
+        s3
+          .getObject({ Bucket, Key })
+          .createReadStream()
+          .pipe(decryptStream(decryptKeyring))
+          // ENCRYPTION-CONTEXT-START: Making Assertions
+          .once("MessageHeader", function(header) {
 
-```
+          })
+      );
 
-```typescript tab="Typescript Node.JS" hl_lines="9 10 11"
-// Edit ./src/retrieve.ts
+    // Save your changes
 
-  return (
-    s3
-      .getObject({ Bucket, Key })
-      .createReadStream()
-      .pipe(decryptStream(decryptKeyring))
-      // ENCRYPTION-CONTEXT-START: Making Assertions
-      .once("MessageHeader", function(this: Writable, header: MessageHeader) {
+    ```
 
-      })
-  );
+=== "Typescript Node.JS"
 
-// Save your changes
+    ```{.typescript hl_lines="9 10 11"}
+    // Edit ./src/retrieve.ts
 
-```
+      return (
+        s3
+          .getObject({ Bucket, Key })
+          .createReadStream()
+          .pipe(decryptStream(decryptKeyring))
+          // ENCRYPTION-CONTEXT-START: Making Assertions
+          .once("MessageHeader", function(this: Writable, header: MessageHeader) {
 
-```python tab="Python" hl_lines="7"
-# Edit src/document_bucket/api.py
-# Find the retrieve(...) function, and use the Encryption SDK header's encryption
-# context to construct the DocumentBundle to return
+          })
+      );
 
-# ENCRYPTION-CONTEXT-START: Use encryption context on Decrypt
-return DocumentBundle.from_data_and_context(
-    plaintext, header.encryption_context
-)
-# Save your changes
-```
+    // Save your changes
+
+    ```
+
+=== "Python"
+
+    ```{.python hl_lines="7"}
+    # Edit src/document_bucket/api.py
+    # Find the retrieve(...) function, and use the Encryption SDK header's encryption
+    # context to construct the DocumentBundle to return
+
+    # ENCRYPTION-CONTEXT-START: Use encryption context on Decrypt
+    return DocumentBundle.from_data_and_context(
+        plaintext, header.encryption_context
+    )
+    # Save your changes
+    ```
 
 #### What Happened?
 
@@ -210,118 +234,126 @@ Next you will add a mechanism for the application to test assertions made in enc
 
 ### Step 3: Making Assertions
 
-```java tab="Java" hl_lines="3 4 14 15 16"
-// Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find retrieve(...)
-    // ENCRYPTION-CONTEXT-START: Making Assertions
-    boolean allExpectedContextKeysFound = actualContext.keySet().containsAll(expectedContextKeys);
-    if (!allExpectedContextKeysFound) {
-        // Remove all of the keys that were found
-        expectedContextKeys.removeAll(actualContext.keySet());
-        String error =
-        String.format(
-            "Expected context keys were not found in the actual encryption context! "
-            + "Missing keys were: %s",
-            expectedContextKeys.toString());
-       throw new DocumentBucketException(error, new NoSuchElementException());
-    }
-    boolean allExpectedContextFound =
-        actualContext.entrySet().containsAll(expectedContext.entrySet());
-    if (!allExpectedContextFound) {
-        Set<Map.Entry<String, String>> expectedContextEntries = expectedContext.entrySet();
-        expectedContextEntries.removeAll(actualContext.entrySet());
-        String error =
+=== "Java"
+
+    ```{.java hl_lines="3 4 14 15 16"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find retrieve(...)
+        // ENCRYPTION-CONTEXT-START: Making Assertions
+        boolean allExpectedContextKeysFound = actualContext.keySet().containsAll(expectedContextKeys);
+        if (!allExpectedContextKeysFound) {
+            // Remove all of the keys that were found
+            expectedContextKeys.removeAll(actualContext.keySet());
+            String error =
             String.format(
-                "Expected context pairs were not found in the actual encryption context! "
-                + "Missing pairs were: %s",
-                expectedContextEntries.toString());
-        throw new DocumentBucketException(error, new NoSuchElementException());
-   }
-// Save your work
-```
-
-```javascript tab="JavaScript Node.JS" hl_lines="9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24"
-// Edit ./retrieve.js
-  return (
-    s3
-      .getObject({ Bucket, Key })
-      .createReadStream()
-      .pipe(decryptStream(decryptKeyring))
-      // ENCRYPTION-CONTEXT-START: Making Assertions
-      .once("MessageHeader", function(header) {
-        const { encryptionContext } = header;
-        const pairs = Object.entries(expectedContext || {});
-        const keys = (expectedContextKeys || []).slice();
-        if (
-          !(
-            pairs.every(([key, value]) => encryptionContext[key] === value) &&
-            keys.every(key =>
-              Object.hasOwnProperty.call(encryptionContext, key)
-            )
-          )
-        ) {
-          this.emit(
-            "error",
-            new Error("Encryption context does not match expected shape")
-          );
+                "Expected context keys were not found in the actual encryption context! "
+                + "Missing keys were: %s",
+                expectedContextKeys.toString());
+          throw new DocumentBucketException(error, new NoSuchElementException());
         }
-      })
-  );
+        boolean allExpectedContextFound =
+            actualContext.entrySet().containsAll(expectedContext.entrySet());
+        if (!allExpectedContextFound) {
+            Set<Map.Entry<String, String>> expectedContextEntries = expectedContext.entrySet();
+            expectedContextEntries.removeAll(actualContext.entrySet());
+            String error =
+                String.format(
+                    "Expected context pairs were not found in the actual encryption context! "
+                    + "Missing pairs were: %s",
+                    expectedContextEntries.toString());
+            throw new DocumentBucketException(error, new NoSuchElementException());
+      }
+    // Save your work
+    ```
 
-// Save your changes
-```
+=== "JavaScript Node.JS"
 
-```typescript tab="Typescript Node.JS" hl_lines="9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24"
-// Edit ./src/retrieve.ts
-  return (
-    s3
-      .getObject({ Bucket, Key })
-      .createReadStream()
-      .pipe(decryptStream(decryptKeyring))
-      // ENCRYPTION-CONTEXT-START: Making Assertions
-      .once("MessageHeader", function(this: Writable, header: MessageHeader) {
-        const { encryptionContext } = header;
-        const pairs = Object.entries(expectedContext || {});
-        const keys = (expectedContextKeys || []).slice();
-        if (
-          !(
-            pairs.every(([key, value]) => encryptionContext[key] === value) &&
-            keys.every(key =>
-              Object.hasOwnProperty.call(encryptionContext, key)
-            )
-          )
-        ) {
-          this.emit(
-            "error",
-            new Error("Encryption context does not match expected shape")
-          );
-        }
-      })
-  );
+    ```{.javascript hl_lines="9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24"}
+    // Edit ./retrieve.js
+      return (
+        s3
+          .getObject({ Bucket, Key })
+          .createReadStream()
+          .pipe(decryptStream(decryptKeyring))
+          // ENCRYPTION-CONTEXT-START: Making Assertions
+          .once("MessageHeader", function(header) {
+            const { encryptionContext } = header;
+            const pairs = Object.entries(expectedContext || {});
+            const keys = (expectedContextKeys || []).slice();
+            if (
+              !(
+                pairs.every(([key, value]) => encryptionContext[key] === value) &&
+                keys.every(key =>
+                  Object.hasOwnProperty.call(encryptionContext, key)
+                )
+              )
+            ) {
+              this.emit(
+                "error",
+                new Error("Encryption context does not match expected shape")
+              );
+            }
+          })
+      );
 
-// Save your changes
-```
+    // Save your changes
+    ```
 
-```python tab="Python" hl_lines="6 13"
-# Edit src/document_bucket/api.py
-# Find the retrieve(...) function, and add some assertions about the contents
-# of the encryption context validated by the Encryption SDK
+=== "Typescript Node.JS"
 
-# ENCRYPTION-CONTEXT-START: Making Assertions
-if not expected_context_keys <= header.encryption_context.keys():
-    error_msg = (
-        "Encryption context assertion failed! "
-        f"Expected all these keys: {expected_context_keys}, "
-        f"but got {header.encryption_context}!"
-    )
-    raise AssertionError(error_msg)
-if not expected_context.items() <= header.encryption_context.items():
-    error_msg = (
-        "Encryption context assertion failed! "
-        f"Expected {expected_context}, "
-        f"but got {header.encryption_context}!"
-    )
-    raise AssertionError(error_msg)
-```
+    ```{.typescript hl_lines="9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24"}
+    // Edit ./src/retrieve.ts
+      return (
+        s3
+          .getObject({ Bucket, Key })
+          .createReadStream()
+          .pipe(decryptStream(decryptKeyring))
+          // ENCRYPTION-CONTEXT-START: Making Assertions
+          .once("MessageHeader", function(this: Writable, header: MessageHeader) {
+            const { encryptionContext } = header;
+            const pairs = Object.entries(expectedContext || {});
+            const keys = (expectedContextKeys || []).slice();
+            if (
+              !(
+                pairs.every(([key, value]) => encryptionContext[key] === value) &&
+                keys.every(key =>
+                  Object.hasOwnProperty.call(encryptionContext, key)
+                )
+              )
+            ) {
+              this.emit(
+                "error",
+                new Error("Encryption context does not match expected shape")
+              );
+            }
+          })
+      );
+
+    // Save your changes
+    ```
+
+=== "Python"
+
+    ```{.python hl_lines="6 13"}
+    # Edit src/document_bucket/api.py
+    # Find the retrieve(...) function, and add some assertions about the contents
+    # of the encryption context validated by the Encryption SDK
+
+    # ENCRYPTION-CONTEXT-START: Making Assertions
+    if not expected_context_keys <= header.encryption_context.keys():
+        error_msg = (
+            "Encryption context assertion failed! "
+            f"Expected all these keys: {expected_context_keys}, "
+            f"but got {header.encryption_context}!"
+        )
+        raise AssertionError(error_msg)
+    if not expected_context.items() <= header.encryption_context.items():
+        error_msg = (
+            "Encryption context assertion failed! "
+            f"Expected {expected_context}, "
+            f"but got {header.encryption_context}!"
+        )
+        raise AssertionError(error_msg)
+    ```
 
 #### What Happened?
 
@@ -335,21 +367,29 @@ If you want to check your progress, or compare what you've done versus a finishe
 
 There is a `-complete` folder for each language.
 
-```bash tab="Java"
-cd ~/environment/workshop/exercises/java/encryption-context-complete
-```
+=== "Java"
 
-```bash tab="JavaScript Node.JS"
-cd ~/environment/workshop/exercises/node-javascript/encryption-context-complete
-```
+    ```bash 
+    cd ~/environment/workshop/exercises/java/encryption-context-complete
+    ```
 
-```bash tab="Typescript Node.JS"
-cd ~/environment/workshop/exercises/node-typescript/encryption-context-complete
-```
+=== "JavaScript Node.JS"
 
-```bash tab="Python"
-cd ~/environment/workshop/exercises/python/encryption-context-complete
-```
+    ```bash
+    cd ~/environment/workshop/exercises/node-javascript/encryption-context-complete
+    ```
+
+=== "Typescript Node.JS"
+
+    ```bash
+    cd ~/environment/workshop/exercises/node-typescript/encryption-context-complete
+    ```
+
+=== "Python"
+
+    ```bash
+    cd ~/environment/workshop/exercises/python/encryption-context-complete
+    ```
 
 ## Try it Out
 
@@ -368,112 +408,124 @@ Here's some ideas for things to test:
 
 There's a few simple suggestions to get you started in the snippets below.
 
-```bash tab="Java"
-// Compile your code
-mvn compile
+=== "Java"
 
-// To use the API programmatically, use this target to launch jshell
-mvn jshell:run
-/open startup.jsh
-import java.util.HashMap;
-Api documentBucket = App.initializeDocumentBucket();
-HashMap<String, String> context = new HashMap<String, String>();
-context.put("shard", "test");
-context.put("app", "document-bucket");
-context.put("origin", "development");
-documentBucket.list();
-documentBucket.store("Store me in the Document Bucket!".getBytes(), context);
-for (PointerItem item : documentBucket.list()) {
-    DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS(), context);
-    System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
-}
-// Ctrl+D to exit jshell
+    ```bash 
+    // Compile your code
+    mvn compile
 
-// Or, to run logic that you write in App.java, use this target after compile
-mvn exec:java
-```
+    // To use the API programmatically, use this target to launch jshell
+    mvn jshell:run
+    /open startup.jsh
+    import java.util.HashMap;
+    Api documentBucket = App.initializeDocumentBucket();
+    HashMap<String, String> context = new HashMap<String, String>();
+    context.put("shard", "test");
+    context.put("app", "document-bucket");
+    context.put("origin", "development");
+    documentBucket.list();
+    documentBucket.store("Store me in the Document Bucket!".getBytes(), context);
+    for (PointerItem item : documentBucket.list()) {
+        DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS(), context);
+        System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
+    }
+    // Ctrl+D to exit jshell
 
-```javascript tab="JavaScript Node.JS"
-node
-list = require("./list.js")
-store = require("./store.js")
-retrieve = require("./retrieve")
-list().then(console.log)
-encryptionContext = {
-  stage: "demo",
-  purpose: "simple demonstration",
-  origin: "us-east-2"
-}
-store(fs.createReadStream("./store.js"), encryptionContext).then(r => {
-  // Just storing the s3 key
-  key = r.Key
-  console.log(r)
-})
-list().then(console.log)
-retrieve(key, { expectedContext: { stage: "demo"}, expectedContextKeys: [ "purpose" ] }).pipe(process.stdout)
-// Ctrl-D when finished to exit the REPL
-```
+    // Or, to run logic that you write in App.java, use this target after compile
+    mvn exec:java
+    ```
 
-```bash tab="JavaScript Node.JS CLI"
-./cli.js list
-./cli.js store ./store.js \
-  -c "stage:demo" \
-  -c "purpose:simple demonstration" \
-  -c "origin:us-east-2"
-# Note the "Key" value
-./cli.js list
-# Note the "reference" value
-./cli.js retrieve $KeyOrReferenceValue \
-  -c "stage:demo" \
-  -k purpose
-```
+=== "JavaScript Node.JS"
 
-```typescript tab="Typescript Node.JS"
-node -r ts-node/register
-;({list} = require("./src/list.ts"))
-;({store} = require("./src/store.ts"))
-;({retrieve} = require("./src/retrieve.ts"))
-list().then(console.log)
-encryptionContext = {
-  stage: "demo",
-  purpose: "simple demonstration",
-  origin: "us-east-2"
-}
-store(fs.createReadStream("./src/store.ts"), encryptionContext).then(r => {
-  // Just storing the s3 key
-  key = r.Key
-  console.log(r)
-})
-list().then(console.log)
-retrieve(key, { expectedContext: { stage: "demo"}, expectedContextKeys: [ "purpose" ] }).pipe(process.stdout)
-// Ctrl-D when finished to exit the REPL
-```
+    ```javascript
+    node
+    list = require("./list.js")
+    store = require("./store.js")
+    retrieve = require("./retrieve")
+    list().then(console.log)
+    encryptionContext = {
+      stage: "demo",
+      purpose: "simple demonstration",
+      origin: "us-east-2"
+    }
+    store(fs.createReadStream("./store.js"), encryptionContext).then(r => {
+      // Just storing the s3 key
+      key = r.Key
+      console.log(r)
+    })
+    list().then(console.log)
+    retrieve(key, { expectedContext: { stage: "demo"}, expectedContextKeys: [ "purpose" ] }).pipe(process.stdout)
+    // Ctrl-D when finished to exit the REPL
+    ```
 
-```bash tab="Typescript Node.JS CLI"
-./cli.ts list
-./cli.ts store ./store.js \
-  -c "stage:demo" \
-  -c "purpose:simple demonstration" \
-  -c "origin:us-east-2"
-# Note the "Key" value
-./cli.ts list
-# Note the "reference" value
-./cli.ts retrieve $KeyOrReferenceValue \
-  -c "stage:demo" \
-  -k purpose
-```
+=== "JavaScript Node.JS CLI"
 
-```bash tab="Python"
-tox -e repl
-import document_bucket
-ops = document_bucket.initialize()
-context = {"host": "cloud9", "shard": "development", "purpose": "experimental"}
-ops.list()
-ops.store(b'some data', context)
-for item in ops.list():
-    ops.retrieve(item.partition_key, expected_context=context)
-# Ctrl-D when finished to exit the REPL
-```
+    ```bash
+    ./cli.js list
+    ./cli.js store ./store.js \
+      -c "stage:demo" \
+      -c "purpose:simple demonstration" \
+      -c "origin:us-east-2"
+    # Note the "Key" value
+    ./cli.js list
+    # Note the "reference" value
+    ./cli.js retrieve $KeyOrReferenceValue \
+      -c "stage:demo" \
+      -k purpose
+    ```
+
+=== "Typescript Node.JS"
+
+    ```{.typescript}
+    node -r ts-node/register
+    ;({list} = require("./src/list.ts"))
+    ;({store} = require("./src/store.ts"))
+    ;({retrieve} = require("./src/retrieve.ts"))
+    list().then(console.log)
+    encryptionContext = {
+      stage: "demo",
+      purpose: "simple demonstration",
+      origin: "us-east-2"
+    }
+    store(fs.createReadStream("./src/store.ts"), encryptionContext).then(r => {
+      // Just storing the s3 key
+      key = r.Key
+      console.log(r)
+    })
+    list().then(console.log)
+    retrieve(key, { expectedContext: { stage: "demo"}, expectedContextKeys: [ "purpose" ] }).pipe(process.stdout)
+    // Ctrl-D when finished to exit the REPL
+    ```
+
+=== "Typescript Node.JS CLI"
+
+    ```bash
+    ./cli.ts list
+    ./cli.ts store ./store.js \
+      -c "stage:demo" \
+      -c "purpose:simple demonstration" \
+      -c "origin:us-east-2"
+    # Note the "Key" value
+    ./cli.ts list
+    # Note the "reference" value
+    ./cli.ts retrieve $KeyOrReferenceValue \
+      -c "stage:demo" \
+      -k purpose
+    ```
+
+=== "Python"
+
+    ```python
+    tox -e repl
+    import document_bucket
+    ops = document_bucket.initialize()
+    context = {"host": "cloud9", "shard": "development", "purpose": "experimental"}
+    ops.list()
+    ops.store(b'some data', context)
+    for item in ops.list():
+        ops.retrieve(item.partition_key, expected_context=context)
+    # Ctrl-D when finished to exit the REPL
+    ```
 
 ## Explore Further
 

--- a/instructions/docs/getting-started.md
+++ b/instructions/docs/getting-started.md
@@ -68,21 +68,29 @@ If you are working through these exercises in an AWS classroom environment, AWS 
 1. In Cloud9, close your Terminal window and open a new one (`Window -> New Terminal`) to pick up the changes `make bootstrap` installed
 1. Choose your workshop language, and `cd` to its folder under `exercises`
 
-```bash tab="Java"
-cd ~/environment/workshop/exercises/java
-```
+=== "Java"
 
-```bash tab="Typescript Node.JS"
-cd ~/environment/workshop/exercises/node-typescript
-```
+    ```bash 
+    cd ~/environment/workshop/exercises/java
+    ```
 
-```bash tab="JavaScript Node.JS"
-cd ~/environment/workshop/exercises/node-javascript
-```
+=== "Typescript Node.JS"
 
-```bash tab="Python"
-cd ~/environment/workshop/exercises/python
-```
+    ```bash 
+    cd ~/environment/workshop/exercises/node-typescript
+    ```
+
+=== "JavaScript Node.JS"
+
+    ```bash
+    cd ~/environment/workshop/exercises/node-javascript
+    ```
+
+=== "Python"
+
+    ```bash
+    cd ~/environment/workshop/exercises/python
+    ```
 
 **Your environment is ready!** 
 

--- a/instructions/docs/multi-cmk.md
+++ b/instructions/docs/multi-cmk.md
@@ -36,57 +36,73 @@ If you just finished [Adding the Encryption SDK](./adding-the-encryption-sdk.md)
 
 If you aren't sure, or want to catch up, jump into the `multi-cmk-start` directory for the language of your choice.
 
-```bash tab="Java"
-cd ~/environment/workshop/exercises/java/multi-cmk-start
-```
+=== "Java"
 
-```bash tab="Typescript Node.JS"
-cd ~/environment/workshop/exercises/node-typescript/multi-cmk-start
-```
+    ```bash 
+    cd ~/environment/workshop/exercises/java/multi-cmk-start
+    ```
 
-```bash tab="JavaScript Node.JS"
-cd ~/environment/workshop/exercises/node-javascript/multi-cmk-start
-```
+=== "Typescript Node.JS"
 
-```bash tab="Python"
-cd ~/environment/workshop/exercises/python/multi-cmk-start
-```
+    ```bash
+    cd ~/environment/workshop/exercises/node-typescript/multi-cmk-start
+    ```
+
+=== "JavaScript Node.JS"
+
+    ```bash
+    cd ~/environment/workshop/exercises/node-javascript/multi-cmk-start
+    ```
+
+=== "Python"
+
+    ```bash
+    cd ~/environment/workshop/exercises/python/multi-cmk-start
+    ```
 
 ### Step 1: Configure Walter
 
-```java tab="Java" hl_lines="4"
-// Edit ./src/main/java/sfw/example/esdkworkshop/App.java
-    String faytheCMK = stateConfig.contents.state.faytheCMK;
+=== "Java"
+
+    ```{.java hl_lines="4"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/App.java
+        String faytheCMK = stateConfig.contents.state.faytheCMK;
+        // MULTI-CMK-START: Configure Walter
+        String walterCMK = stateConfig.contents.state.WalterCMK;
+    ```
+
+=== "JavaScript Node.JS"
+
+    ```{.javascript hl_lines="3 7"}
+    // Edit ./store.js
     // MULTI-CMK-START: Configure Walter
-    String walterCMK = stateConfig.contents.state.WalterCMK;
-```
+    const walterCMK = config.state.getWalterCMK();
 
-```javascript tab="JavaScript Node.JS" hl_lines="3 7"
-// Edit ./store.js
-// MULTI-CMK-START: Configure Walter
-const walterCMK = config.state.getWalterCMK();
+    // Edit ./retrieve.js
+    // MULTI-CMK-START: Configure Walter
+    const walterCMK = config.state.getWalterCMK();
+    ```
 
-// Edit ./retrieve.js
-// MULTI-CMK-START: Configure Walter
-const walterCMK = config.state.getWalterCMK();
-```
+=== "Typescript Node.JS"
 
-```typescript tab="Typescript Node.JS" hl_lines="3 7"
-// Edit ./src/store.ts
-// MULTI-CMK-START: Configure Walter
-const walterCMK = config.state.getWalterCMK();
+    ```{.typescript hl_lines="3 7"}
+    // Edit ./src/store.ts
+    // MULTI-CMK-START: Configure Walter
+    const walterCMK = config.state.getWalterCMK();
 
-// Edit ./src/retrieve.ts
-// MULTI-CMK-START: Configure Walter
-const walterCMK = config.state.getWalterCMK();
-```
+    // Edit ./src/retrieve.ts
+    // MULTI-CMK-START: Configure Walter
+    const walterCMK = config.state.getWalterCMK();
+    ```
 
-```python tab="Python" hl_lines="4"
-# Edit src/document_bucket/__init__.py
+=== "Python"
 
-# MULTI-CMK-START: Configure Walter
-walter_cmk = state["WalterCMK"]
-```
+    ```{.python hl_lines="4"}
+    # Edit src/document_bucket/__init__.py
+
+    # MULTI-CMK-START: Configure Walter
+    walter_cmk = state["WalterCMK"]
+    ```
 
 #### What Happened?
 
@@ -94,57 +110,65 @@ When you launched your workshop stacks in [Getting Started](./getting-started.md
 
 ### Step 2: Add Walter to the CMKs to Use
 
-```java tab="Java" hl_lines="3 4"
-// Edit ./src/main/java/sfw/example/esdkworkshop/App.java
+=== "Java"
+
+    ```{.java hl_lines="3 4"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/App.java
+        // MULTI-CMK-START: Add Walter to the CMKs to Use
+        KmsMasterKeyProvider mkp =
+            KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK, walterCMK).build();
+    ```
+
+=== "JavaScript Node.JS"
+
+    ```{.javascript hl_lines="4 5 6 7 13"}
+    // Edit ./store.js
     // MULTI-CMK-START: Add Walter to the CMKs to Use
-    KmsMasterKeyProvider mkp =
-        KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK, walterCMK).build();
-```
+    ...
+    const encryptKeyring = new KmsKeyringNode({
+      generatorKeyId: faytheCMK,
+      keyIds: [walterCMK]
+    });
 
-```javascript tab="JavaScript Node.JS" hl_lines="4 5 6 7 13"
-// Edit ./store.js
-// MULTI-CMK-START: Add Walter to the CMKs to Use
-...
-const encryptKeyring = new KmsKeyringNode({
-  generatorKeyId: faytheCMK,
-  keyIds: [walterCMK]
-});
+    // Save and exit
+    // Edit ./retrieve.js
+    // MULTI-CMK-START: Add Walter to the CMKs to Use
+    ...
+    const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK, walterCMK] });
 
-// Save and exit
-// Edit ./retrieve.js
-// MULTI-CMK-START: Add Walter to the CMKs to Use
-...
-const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK, walterCMK] });
+    // Save and exit
+    ```
 
-// Save and exit
-```
+=== "Typescript Node.JS"
 
-```typescript tab="Typescript Node.JS" hl_lines="4 5 6 7 13"
-// Edit ./src/store.ts
-// MULTI-CMK-START: Add Walter to the CMKs to Use
-...
-const encryptKeyring = new KmsKeyringNode({
-  generatorKeyId: faytheCMK,
-  keyIds: [walterCMK]
-});
+    ```{.typescript hl_lines="4 5 6 7 13"}
+    // Edit ./src/store.ts
+    // MULTI-CMK-START: Add Walter to the CMKs to Use
+    ...
+    const encryptKeyring = new KmsKeyringNode({
+      generatorKeyId: faytheCMK,
+      keyIds: [walterCMK]
+    });
 
-// Save and exit
-// Edit ./src/retrieve.ts
-// MULTI-CMK-START: Add Walter to the CMKs to Use
-...
-const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK, walterCMK] });
+    // Save and exit
+    // Edit ./src/retrieve.ts
+    // MULTI-CMK-START: Add Walter to the CMKs to Use
+    ...
+    const decryptKeyring = new KmsKeyringNode({ keyIds: [faytheCMK, walterCMK] });
 
-// Save and exit
-```
+    // Save and exit
+    ```
 
-```python tab="Python" hl_lines="4"
-# Edit src/document_bucket/__init__.py
+=== "Python"
 
-# MULTI-CMK-START: Add Walter to the CMKs to Use
-cmk = [faythe_cmk, walter_cmk]
+    ```{.python hl_lines="4"}
+    # Edit src/document_bucket/__init__.py
 
-# Save and exit
-```
+    # MULTI-CMK-START: Add Walter to the CMKs to Use
+    cmk = [faythe_cmk, walter_cmk]
+
+    # Save and exit
+    ```
 
 #### What Happened?
 
@@ -156,21 +180,29 @@ If you want to check your progress, or compare what you've done versus a finishe
 
 There is a `-complete` folder for each language.
 
-```bash tab="Java"
-cd ~/environment/workshop/exercises/java/multi-cmk-complete
-```
+=== "Java"
 
-```bash tab="Typescript Node.JS"
-cd ~/environment/workshop/exercises/node-typescript/multi-cmk-complete
-```
+    ```bash 
+    cd ~/environment/workshop/exercises/java/multi-cmk-complete
+    ```
 
-```bash tab="JavaScript Node.JS"
-cd ~/environment/workshop/exercises/node-javascript/multi-cmk-complete
-```
+=== "Typescript Node.JS"
 
-```bash tab="Python"
-cd ~/environment/workshop/exercises/python/multi-cmk-complete
-```
+    ```bash
+    cd ~/environment/workshop/exercises/node-typescript/multi-cmk-complete
+    ```
+
+=== "JavaScript Node.JS"
+
+    ```bash
+    cd ~/environment/workshop/exercises/node-javascript/multi-cmk-complete
+    ```
+
+=== "Python"
+
+    ```bash
+    cd ~/environment/workshop/exercises/python/multi-cmk-complete
+    ```
 
 ## Try it Out
 
@@ -212,92 +244,104 @@ Try out combinations of Grant permissions for your application and watch how the
 * Revoke permission to Walter, and encrypt some data with Faythe. Then, add permission back to Walter, revoke permission to use Faythe, and try to decrypt that data
 * What other interesting access patterns can you imagine?
 
-```java tab="Java"
-// Compile your code
-mvn compile
+=== "Java"
 
-// To use the API programmatically, use this target to launch jshell
-mvn jshell:run
-/open startup.jsh
-Api documentBucket = App.initializeDocumentBucket();
-documentBucket.list();
-documentBucket.store("Store me in the Document Bucket!".getBytes());
-for (PointerItem item : documentBucket.list()) {
-    DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS());
-    System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
-}
-// Ctrl+D to exit jshell
+    ```java
+    // Compile your code
+    mvn compile
 
-// Use the make targets to change the Grants and see what happens!
-// To run logic that you write in App.java, use this target after compile
-mvn exec:java
-```
+    // To use the API programmatically, use this target to launch jshell
+    mvn jshell:run
+    /open startup.jsh
+    Api documentBucket = App.initializeDocumentBucket();
+    documentBucket.list();
+    documentBucket.store("Store me in the Document Bucket!".getBytes());
+    for (PointerItem item : documentBucket.list()) {
+        DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS());
+        System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
+    }
+    // Ctrl+D to exit jshell
 
-```javascript tab="JavaScript Node.JS"
-node
-list = require("./list.js")
-store = require("./store.js")
-retrieve = require("./retrieve")
-list().then(console.log)
-store(fs.createReadStream("./store.js")).then(r => {
-  // Just storing the s3 key
-  key = r.Key
-  console.log(r)
-})
-list().then(console.log)
-retrieve(key).pipe(process.stdout)
-// Use the make targets to change the Grants and see what happens!
-// Ctrl-D when finished to exit the REPL
-```
+    // Use the make targets to change the Grants and see what happens!
+    // To run logic that you write in App.java, use this target after compile
+    mvn exec:java
+    ```
 
-```bash tab="JavaScript Node.JS CLI"
-./cli.js list
-./cli.js store ./store.js
-# Note the "Key" value
-./cli.js list
-# Note the "reference" value
-./cli.js retrieve $KeyOrReferenceValue
-# Use the make targets to change the grants and see what happens!
-```
+=== "JavaScript Node.JS"
 
-```typescript tab="Typescript Node.JS"
-node -r ts-node/register
-;({list} = require("./src/list.ts"))
-;({store} = require("./src/store.ts"))
-;({retrieve} = require("./src/retrieve.ts"))
-list().then(console.log)
-store(fs.createReadStream("./src/store.ts")).then(r => {
-  // Just storing the s3 key
-  key = r.Key
-  console.log(r)
-})
-list().then(console.log)
-retrieve(key).pipe(process.stdout)
-// Ctrl-D when finished to exit the REPL
-// Use the make targets to change the Grants and see what happens!
-```
+    ```javascript
+    node
+    list = require("./list.js")
+    store = require("./store.js")
+    retrieve = require("./retrieve")
+    list().then(console.log)
+    store(fs.createReadStream("./store.js")).then(r => {
+      // Just storing the s3 key
+      key = r.Key
+      console.log(r)
+    })
+    list().then(console.log)
+    retrieve(key).pipe(process.stdout)
+    // Use the make targets to change the Grants and see what happens!
+    // Ctrl-D when finished to exit the REPL
+    ```
 
-```bash tab="Typescript Node.JS CLI"
-./cli.ts list
-./cli.ts store ./store.js
-# Note the "Key" value
-./cli.ts list
-# Note the "reference" value
-./cli.ts retrieve $KeyOrReferenceValue
-# Use the make targets to change the grants and see what happens!
-```
+=== "JavaScript Node.JS CLI"
 
-```python tab="Python"
-tox -e repl
-import document_bucket
-ops = document_bucket.initialize()
-ops.list()
-ops.store(b'some data')
-for item in ops.list():
-    print(ops.retrieve(item.partition_key))
-# Use the make targets to change the grants and see what happens!
-# Ctrl-D when finished to exit the REPL
-```
+    ```bash
+    ./cli.js list
+    ./cli.js store ./store.js
+    # Note the "Key" value
+    ./cli.js list
+    # Note the "reference" value
+    ./cli.js retrieve $KeyOrReferenceValue
+    # Use the make targets to change the grants and see what happens!
+    ```
+
+=== "Typescript Node.JS"
+
+    ```{.typescript}
+    node -r ts-node/register
+    ;({list} = require("./src/list.ts"))
+    ;({store} = require("./src/store.ts"))
+    ;({retrieve} = require("./src/retrieve.ts"))
+    list().then(console.log)
+    store(fs.createReadStream("./src/store.ts")).then(r => {
+      // Just storing the s3 key
+      key = r.Key
+      console.log(r)
+    })
+    list().then(console.log)
+    retrieve(key).pipe(process.stdout)
+    // Ctrl-D when finished to exit the REPL
+    // Use the make targets to change the Grants and see what happens!
+    ```
+
+=== "Typescript Node.JS CLI"
+
+    ```bash
+    ./cli.ts list
+    ./cli.ts store ./store.js
+    # Note the "Key" value
+    ./cli.ts list
+    # Note the "reference" value
+    ./cli.ts retrieve $KeyOrReferenceValue
+    # Use the make targets to change the grants and see what happens!
+    ```
+
+=== "Python"
+
+    ```python
+    tox -e repl
+    import document_bucket
+    ops = document_bucket.initialize()
+    ops.list()
+    ops.store(b'some data')
+    for item in ops.list():
+        print(ops.retrieve(item.partition_key))
+    # Use the make targets to change the grants and see what happens!
+    # Ctrl-D when finished to exit the REPL
+    ```
 
 ## Explore Further
 

--- a/instructions/docs/stylesheets/custom.css
+++ b/instructions/docs/stylesheets/custom.css
@@ -1,4 +1,3 @@
-
 .md-header {
     background-color: #232f3e !important;
     border-bottom: 1px solid #1b2532 !important;
@@ -101,7 +100,7 @@
     margin-right: 15px;
 }
 
-.md-content__icon {
+.md-content__button {
     display: none;
 }
 
@@ -117,6 +116,10 @@
 
 .table {
     font-size: medium;
+}
+
+.md-header-nav__button.md-logo img, .md-header-nav__button.md-logo svg {
+    width: 40px
 }
 
 /* Footer */

--- a/instructions/docs/tips-and-troubleshooting.md
+++ b/instructions/docs/tips-and-troubleshooting.md
@@ -23,21 +23,29 @@ Now try your work again.
 
 These commands will check your code for missing imports, syntax issues, and other minor issues that might trip you up.
 
-```bash tab="Java"
-mvn verify
-```
+=== "Java"
 
-```bash tab="JavaScript Node.JS"
-npm run prettier
-```
+    ```bash 
+    mvn verify
+    ```
 
-```bash tab="TypeScript Node.JS"
-npm run prettier
-```
+=== "JavaScript Node.JS"
 
-```bash tab="Python"
-tox -e check
-```
+    ```bash
+    npm run prettier
+    ```
+
+=== "Typescript Node.JS"
+
+    ```bash
+    npm run prettier
+    ```
+
+=== "Python"
+
+    ```bash
+    tox -e check
+    ```
 
 ### Missing CloudFormation resources
 
@@ -92,13 +100,17 @@ sudo resize2fs /dev/nvme0n1p1
 
 Python and Java have API documentation available for each exercise. You can view the documentation as you work in Cloud9.
 
-```bash tab="Java"
-make javadoc
-```
+=== "Java"
 
-```bash tab="Python"
-tox -e docs
-```
+    ```bash 
+    make javadoc
+    ```
+
+=== "Python"
+
+    ```bash
+    tox -e docs
+    ```
 
 Now select "Preview -> Preview Running Application" from the Cloud9 menu bar.
 

--- a/instructions/mkdocs.yml
+++ b/instructions/mkdocs.yml
@@ -10,40 +10,40 @@ repo_name: 'aws-samples/busy-engineers-document-bucket'
 repo_url: 'https://github.com/aws-samples/busy-engineers-document-bucket'
 
 # Copyright
-copyright: '&copy; 2019, Amazon Web Services, Inc. or its affiliates. All rights reserved.'
+copyright: '<a href="https://aws.amazon.com/privacy/" target="_blank">Privacy</a> | <a href="https://aws.amazon.com/terms/" target="_blank">Site terms</a> | &copy; 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved.'
 
 # Configuration
 theme:
   name: 'material'
   logo: 'assets/images/aws_smile_logo.png'
   favicon: 'assets/images/aws-favicon.ico'
-  feature:
-    tabs: true
-  custom_dir: 'docs/theme'
+  features:
+    - tabs
+  font: false
 
 # Customization
 extra_css:
   - 'stylesheets/custom.css'
-extra_javascript:
-  - 'javascripts/extra.js'
 extra:
   social:
-    - icon: 'material/home'
-      link: 'https://awssecworkshops.com'
-    - icon: 'material/shield-half-full'
-      link: 'https://aws.amazon.com/security/'
-    - icon: 'material/twitter'
-      link: 'https://twitter.com/awssecurityinfo?lang=en'
-    - icon: 'material/rss'
-      link: 'https://aws.amazon.com/blogs/security/'
+    - icon: fontawesome/solid/house    
+      link: https://awssecworkshops.com
+    - icon: fontawesome/solid/shield
+      link: https://aws.amazon.com/security/
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/awssecurityinfo?lang=en
+    - icon: fontawesome/solid/square-rss
+      link: https://aws.amazon.com/blogs/security/
 
 # Extensions
 markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
-  - codehilite:
+  - pymdownx.highlight:
         linenums: true
+  - pymdownx.tabbed:
+        alternate_style: true
 
 # Navigation
 nav:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The old style of codeblock tabs are deprecated with the latest version of Materials for MkDocs. This PR updates to use the latest style for tabs with codeblocks, as well as a couple other surface level updates to better match style with https://awssecworkshops.com/

Additionally, a couple of the highlighted lines in the codeblock sections were not updates with the latest commitment changes. This PR fixes these errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
