### PR TITLE
fix: Fix Java exercises

### DIFF
--- a/exercises/java/add-esdk-complete/pom.xml
+++ b/exercises/java/add-esdk-complete/pom.xml
@@ -65,6 +65,11 @@
             <version>1.2.0</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -41,37 +41,7 @@ public class Api {
   private final String bucketName;
 
   /**
-   * Construct a Document Bucket {@code Api} using a default {@link AwsCrypto} instance.
-   *
-   * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
-   * @param tableName the name of the Document Bucket table.
-   * @param s3Client the {@link AmazonS3} to use to interact with Amazon S3.
-   * @param bucketName the name of the Document Bucket, err, bucket.
-   * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
-   *     {@link AwsCrypto}.
-   */
-  public Api(
-      AmazonDynamoDB ddbClient,
-      String tableName,
-      AmazonS3 s3Client,
-      String bucketName,
-      // ADD-ESDK-COMPLETE: Add the ESDK Dependency
-      MasterKeyProvider mkp) {
-    // ADD-ESDK-COMPLETE: Add the ESDK Dependency
-    this(
-        ddbClient,
-        tableName,
-        s3Client,
-        bucketName,
-        AwsCrypto.builder()
-            .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
-            .build(),
-        mkp);
-  }
-
-  /**
-   * Construct a Document Bucket {@code Api} using the provided {@link AwsCrypto} instance.
-   * (Included to facilitate unit testing.)
+   * Construct a Document Bucket {@code Api} using the provided configuration.
    *
    * @param ddbClient the {@link AmazonDynamoDB} to use to interact with Amazon DynamoDB.
    * @param tableName the name of the Document Bucket table.
@@ -82,20 +52,21 @@ public class Api {
    * @param mkp the {@link MasterKeyProvider} to use for Encryption and Decryption operations with
    *     {@link AwsCrypto}.
    */
-  protected Api(
+  public Api(
+      // ADD-ESDK-COMPLETE: Add the ESDK Dependency
       AmazonDynamoDB ddbClient,
       String tableName,
       AmazonS3 s3Client,
       String bucketName,
-      // ADD-ESDK-COMPLETE: Add the ESDK Dependency
-      AwsCrypto awsEncryptionSdk,
       MasterKeyProvider<? extends MasterKey> mkp) {
     this.ddbClient = ddbClient;
     this.tableName = tableName;
     this.s3Client = s3Client;
     this.bucketName = bucketName;
     // ADD-ESDK-COMPLETE: Add the ESDK Dependency
-    this.awsEncryptionSdk = awsEncryptionSdk;
+    this.awsEncryptionSdk = AwsCrypto.builder()
+        .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+        .build();
     this.mkp = mkp;
   }
 

--- a/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -128,11 +128,13 @@ public class Api {
    */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
+    byte[] data = bundle.getData();
+    metadata.setContentLength(data.length);
     metadata.setUserMetadata(bundle.getPointer().getContext());
     s3Client.putObject(
         bucketName,
         bundle.getPointer().partitionKey().getS(),
-        new ByteArrayInputStream(bundle.getData()),
+        new ByteArrayInputStream(data),
         metadata);
   }
 

--- a/exercises/java/add-esdk-start/pom.xml
+++ b/exercises/java/add-esdk-start/pom.xml
@@ -65,6 +65,11 @@
             <version>1.2.0</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -111,11 +111,13 @@ public class Api {
    */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
+    byte[] data = bundle.getData();
+    metadata.setContentLength(data.length);
     metadata.setUserMetadata(bundle.getPointer().getContext());
     s3Client.putObject(
         bucketName,
         bundle.getPointer().partitionKey().getS(),
-        new ByteArrayInputStream(bundle.getData()),
+        new ByteArrayInputStream(data),
         metadata);
   }
 

--- a/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/add-esdk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -42,7 +42,10 @@ public class Api {
    */
   public Api(
       // ADD-ESDK-START: Add the ESDK Dependency
-      AmazonDynamoDB ddbClient, String tableName, AmazonS3 s3Client, String bucketName) {
+      AmazonDynamoDB ddbClient,
+      String tableName,
+      AmazonS3 s3Client,
+      String bucketName) {
     this.ddbClient = ddbClient;
     this.tableName = tableName;
     this.s3Client = s3Client;
@@ -66,7 +69,7 @@ public class Api {
   /**
    * Retrieves a {@link PointerItem} for the supplied key.
    *
-   * @param key the key for which to fetch the {@link PointerItem}.
+   * @param key the key to fetch the {@link PointerItem}.
    * @return the {@link PointerItem} found.
    */
   protected PointerItem getPointerItem(String key) {
@@ -88,7 +91,7 @@ public class Api {
   /**
    * Query DynamoDB for the records associated with the supplied context key.
    *
-   * @param contextKey the key for which to retrieve the list of matching records.
+   * @param contextKey the key to retrieve the list of matching records.
    * @return the {@link Set} of {@link PointerItem}s that have that context key.
    */
   protected Set<PointerItem> queryForContextKey(String contextKey) {
@@ -225,7 +228,7 @@ public class Api {
   /**
    * Search the Document Bucket for any documents that have context with the supplied key.
    *
-   * @param contextKey the key for which to search for matching documents.
+   * @param contextKey the key to search for matching documents.
    * @return the {@link Set} of {@link PointerItem}s for matching documents.
    */
   public Set<PointerItem> searchByContextKey(String contextKey) {

--- a/exercises/java/encryption-context-complete/pom.xml
+++ b/exercises/java/encryption-context-complete/pom.xml
@@ -65,6 +65,11 @@
             <version>1.2.0</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -152,11 +152,13 @@ public class Api {
    */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
+    byte[] data = bundle.getData();
+    metadata.setContentLength(data.length);
     metadata.setUserMetadata(bundle.getPointer().getContext());
     s3Client.putObject(
         bucketName,
         bundle.getPointer().partitionKey().getS(),
-        new ByteArrayInputStream(bundle.getData()),
+        new ByteArrayInputStream(data),
         metadata);
   }
 

--- a/exercises/java/encryption-context-start/pom.xml
+++ b/exercises/java/encryption-context-start/pom.xml
@@ -65,6 +65,11 @@
             <version>1.2.0</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/encryption-context-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -151,11 +151,13 @@ public class Api {
    */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
+    byte[] data = bundle.getData();
+    metadata.setContentLength(data.length);
     metadata.setUserMetadata(bundle.getPointer().getContext());
     s3Client.putObject(
         bucketName,
         bundle.getPointer().partitionKey().getS(),
-        new ByteArrayInputStream(bundle.getData()),
+        new ByteArrayInputStream(data),
         metadata);
   }
 

--- a/exercises/java/multi-cmk-complete/pom.xml
+++ b/exercises/java/multi-cmk-complete/pom.xml
@@ -65,6 +65,11 @@
             <version>1.2.0</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-complete/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -151,11 +151,13 @@ public class Api {
    */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
+    byte[] data = bundle.getData();
+    metadata.setContentLength(data.length);
     metadata.setUserMetadata(bundle.getPointer().getContext());
     s3Client.putObject(
         bucketName,
         bundle.getPointer().partitionKey().getS(),
-        new ByteArrayInputStream(bundle.getData()),
+        new ByteArrayInputStream(data),
         metadata);
   }
 

--- a/exercises/java/multi-cmk-start/pom.xml
+++ b/exercises/java/multi-cmk-start/pom.xml
@@ -65,6 +65,11 @@
             <version>1.2.0</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
+++ b/exercises/java/multi-cmk-start/src/main/java/sfw/example/esdkworkshop/Api.java
@@ -151,11 +151,13 @@ public class Api {
    */
   protected void writeObject(DocumentBundle bundle) {
     ObjectMetadata metadata = new ObjectMetadata();
+    byte[] data = bundle.getData();
+    metadata.setContentLength(data.length);
     metadata.setUserMetadata(bundle.getPointer().getContext());
     s3Client.putObject(
         bucketName,
         bundle.getPointer().partitionKey().getS(),
-        new ByteArrayInputStream(bundle.getData()),
+        new ByteArrayInputStream(data),
         metadata);
   }
 

--- a/instructions/docs/adding-the-encryption-sdk.md
+++ b/instructions/docs/adding-the-encryption-sdk.md
@@ -453,7 +453,7 @@ Experiment using the API as much as you like.
 
 To get started, here are some things to try:
 
-* Compare <a href="https://us-east-2.console.aws.amazon.com/cloudtrail/home?region=us-east-2#" target="_blank">CloudTrail Logs for usages of Faythe</a> when you encrypt messages of different sizes (small, medium, large)
+* Compare <a href="https://us-east-2.console.aws.amazon.com/cloudtrail/home?region=us-east-2#/events?EventSource=kms.amazonaws.com" target="_blank">CloudTrail Logs for usages of Faythe</a> when you encrypt messages of different sizes (small, medium, large)
 * Take a look at the <a href="https://s3.console.aws.amazon.com/s3/home" target="_blank">contents of your S3 Document Bucket</a> to inspect the raw object
 
 

--- a/instructions/docs/adding-the-encryption-sdk.md
+++ b/instructions/docs/adding-the-encryption-sdk.md
@@ -46,39 +46,42 @@ Start by adding the Encryption SDK dependency to the code.
 
 === "Java"
 
-    ```{.java hl_lines="5 6 7 8 9 15 16 26 31 32 40"}
+    ```{.java hl_lines="5 6 7 8 9 10 16 17 27 32 33 34 35 43"}
     // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
     package sfw.example.esdkworkshop;
 
     // ADD-ESDK-START: Add the ESDK Dependency
     import com.amazonaws.encryptionsdk.AwsCrypto;
+    import com.amazonaws.encryptionsdk.CommitmentPolicy;
     import com.amazonaws.encryptionsdk.CryptoResult;
     import com.amazonaws.encryptionsdk.MasterKey;
     import com.amazonaws.encryptionsdk.MasterKeyProvider;
     import com.amazonaws.encryptionsdk.kms.KmsMasterKey;
 
     ...
-    private final String tableName;
-    private final String bucketName;
-    // ADD-ESDK-START: Add the ESDK Dependency
-    private final AwsCrypto awsEncryptionSdk;
-    private final MasterKeyProvider mkp;
+      private final String tableName;
+      private final String bucketName;
+      // ADD-ESDK-START: Add the ESDK Dependency
+      private final AwsCrypto awsEncryptionSdk;
+      private final MasterKeyProvider mkp;
 
     ...
 
     public Api(
+        // ADD-ESDK-START: Add the ESDK Dependency
         AmazonDynamoDB ddbClient,
         String tableName,
         AmazonS3 s3Client,
         String bucketName,
-        // ADD-ESDK-START: Add the ESDK Dependency
         MasterKeyProvider<? extends MasterKey> mkp) {
-    this.ddbClient = ddbClient;
-    this.tableName = tableName;
-    this.s3Client = s3Client
-    // ADD-ESDK-START: Add the ESDK Dependency
-    this.awsEncryptionSdk = new AwsCrypto();
-    this.mkp = mkp;
+      this.ddbClient = ddbClient;
+      this.tableName = tableName;
+      this.s3Client = s3Client
+      // ADD-ESDK-START: Add the ESDK Dependency
+      this.awsEncryptionSdk = AwsCrypto.builder()
+          .withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt)
+          .build();
+      this.mkp = mkp;
     }
 
     // Save and close.
@@ -245,13 +248,14 @@ Now that the application encypts your data before storing it, it will need to de
 
 === "Java"
 
-    ```{.java hl_lines="5 7"}
+    ```{.java hl_lines="5 8"}
     // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
     // Find retrieve(...)
         byte[] data = getObjectData(key);
         // ADD-ESDK-START: Add Decryption to retrieve
         CryptoResult<byte[], KmsMasterKey> decryptedMessage = awsEncryptionSdk.decryptData(mkp, data);
-        ...
+        PointerItem pointer = getPointerItem(key);
+        // ADD-ESDK-START: Add Decryption to retrieve
         return DocumentBundle.fromDataAndPointer(decryptedMessage.getResult(), pointer);
     ```
 
@@ -323,7 +327,7 @@ Now that you have declared your dependencies and updated your code to encrypt an
 
 === "Java"
 
-    ```{.java hl_lines="6 9 10 12"}
+    ```{.java hl_lines="6 9 11"}
     // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
         AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
 
@@ -332,8 +336,7 @@ Now that you have declared your dependencies and updated your code to encrypt an
         String faytheCMK = stateConfig.contents.state.FaytheCMK;
 
         // Set up the Master Key Provider to use KMS
-        KmsMasterKeyProvider mkp =
-            KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK).build();
+        KmsMasterKeyProvider mkp = KmsMasterKeyProvider.builder().buildStrict(faytheCMK);
 
         return new Api(ddbClient, tableName, s3Client, bucketName, mkp);
     ```

--- a/instructions/docs/encryption-context.md
+++ b/instructions/docs/encryption-context.md
@@ -99,8 +99,17 @@ If you aren't sure, or want to catch up, jump into the `encryption-context-start
 
 === "Java"
 
-    ```{.java hl_lines="4"}
-    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find store(...)
+    ```{.java hl_lines="5 12 13"}
+    // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java
+    ...
+
+    import java.util.Map;
+    import java.util.NoSuchElementException;
+    import java.util.Set;
+
+    ...
+
+      public PointerItem store(byte[] data, Map<String, String> context) {
         // ENCRYPTION-CONTEXT-START: Set Encryption Context on Encrypt
         CryptoResult<byte[], KmsMasterKey> encryptedMessage =
             awsEncryptionSdk.encryptData(mkp, data, context);
@@ -236,7 +245,7 @@ Next you will add a mechanism for the application to test assertions made in enc
 
 === "Java"
 
-    ```{.java hl_lines="3 4 14 15 16"}
+    ```{.java hl_lines="3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25"}
     // Edit ./src/main/java/sfw/example/esdkworkshop/Api.java and find retrieve(...)
         // ENCRYPTION-CONTEXT-START: Making Assertions
         boolean allExpectedContextKeysFound = actualContext.keySet().containsAll(expectedContextKeys);
@@ -261,7 +270,7 @@ Next you will add a mechanism for the application to test assertions made in enc
                     + "Missing pairs were: %s",
                     expectedContextEntries.toString());
             throw new DocumentBucketException(error, new NoSuchElementException());
-      }
+        }
     // Save your work
     ```
 

--- a/instructions/docs/encryption-context.md
+++ b/instructions/docs/encryption-context.md
@@ -433,11 +433,9 @@ There's a few simple suggestions to get you started in the snippets below.
     context.put("app", "document-bucket");
     context.put("origin", "development");
     documentBucket.list();
-    documentBucket.store("Store me in the Document Bucket!".getBytes(), context);
-    for (PointerItem item : documentBucket.list()) {
-        DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS(), context);
-        System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
-    }
+    PointerItem item = documentBucket.store("Store me in the Document Bucket!".getBytes(), context);
+    DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS(), context);
+    System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
     // Ctrl+D to exit jshell
 
     // Or, to run logic that you write in App.java, use this target after compile

--- a/instructions/docs/multi-cmk.md
+++ b/instructions/docs/multi-cmk.md
@@ -254,8 +254,8 @@ Try out combinations of Grant permissions for your application and watch how the
     /open startup.jsh
     Api documentBucket = App.initializeDocumentBucket();
     documentBucket.list();
-    PointerItem item = documentBucket.store("Store me in the Document Bucket!".getBytes(), context);
-    DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS(), context);
+    PointerItem item = documentBucket.store("Store me in the Document Bucket!".getBytes());
+    DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS());
     System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
     // Ctrl+D to exit jshell
 

--- a/instructions/docs/multi-cmk.md
+++ b/instructions/docs/multi-cmk.md
@@ -254,11 +254,9 @@ Try out combinations of Grant permissions for your application and watch how the
     /open startup.jsh
     Api documentBucket = App.initializeDocumentBucket();
     documentBucket.list();
-    documentBucket.store("Store me in the Document Bucket!".getBytes());
-    for (PointerItem item : documentBucket.list()) {
-        DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS());
-        System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
-    }
+    PointerItem item = documentBucket.store("Store me in the Document Bucket!".getBytes(), context);
+    DocumentBundle document = documentBucket.retrieve(item.partitionKey().getS(), context);
+    System.out.println(document.getPointer().partitionKey().getS() + " : " + new String(document.getData(), java.nio.charset.StandardCharsets.UTF_8));
     // Ctrl+D to exit jshell
 
     // Use the make targets to change the Grants and see what happens!

--- a/instructions/docs/multi-cmk.md
+++ b/instructions/docs/multi-cmk.md
@@ -112,11 +112,10 @@ When you launched your workshop stacks in [Getting Started](./getting-started.md
 
 === "Java"
 
-    ```{.java hl_lines="3 4"}
+    ```{.java hl_lines="3"}
     // Edit ./src/main/java/sfw/example/esdkworkshop/App.java
         // MULTI-CMK-START: Add Walter to the CMKs to Use
-        KmsMasterKeyProvider mkp =
-            KmsMasterKeyProvider.builder().withKeysForEncryption(faytheCMK, walterCMK).build();
+        KmsMasterKeyProvider mkp = KmsMasterKeyProvider.builder().buildStrict(faytheCMK, walterCMK);
     ```
 
 === "JavaScript Node.JS"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixes the Java instructions to use the newest "complete" version of the code, as well as fix some minor inconsistencies between the "complete" and "start" dirs in exercise 1.

Additionally updates a Cloudtrail link to filter for the right logs (otherwise it defaults to a filter which will never see the KMS logs)

Tested via pulling this branch into cloud9 workshop environment and following instructions build by this fork. Verified that instructions on this fork look good manually.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
