### PR TITLE
fix: add docs CI workflow with mkdocs-material>=9.5.32

### DIFF
--- a/.github/docs.yml
+++ b/.github/docs.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install "mkdocs-material>=9.5.32"
+      - run: pip install -r instructions/requirements.txt
       - run: git fetch origin gh-pages --depth=1
       - run: cd instructions && mkdocs gh-deploy

--- a/.github/docs.yml
+++ b/.github/docs.yml
@@ -1,0 +1,18 @@
+name: docs
+on:
+  push:
+    branches: [master]
+    paths: ['instructions/**']
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install "mkdocs-material>=9.5.32"
+      - run: git fetch origin gh-pages --depth=1
+      - run: cd instructions && mkdocs gh-deploy

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -7,10 +7,10 @@ Workshops from https://github.com/aws-samples/aws-security-workshops
 
 ## Requirements
 
-To build locally or build and deploy the site, you need to install the following:
-
-- [MkDocs](https://www.mkdocs.org/)
-- [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
+To build locally or build and deploy the site, you need to install dependencies. Run following command to install requirements:
+```
+pip install -r requirements.txt
+```
 
 ## Build Locally
 

--- a/instructions/requirements.txt
+++ b/instructions/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.3.0
+mkdocs-material>=9.5.32


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a GitHub Actions workflow to automate documentation builds and deploys with mkdocs-material>=9.5.32 which includes security improvements.

Continuing from PR https://github.com/aws-samples/busy-engineers-document-bucket/pull/294

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
